### PR TITLE
docs: replace stale proxy service name with gateway in docs

### DIFF
--- a/docs/api/languagecluster.md
+++ b/docs/api/languagecluster.md
@@ -21,7 +21,7 @@ spec:
   domain: agents.example.com
 ```
 
-This creates a `production-agents` namespace with the shared proxy accessible at `http://proxy.production-agents.svc.cluster.local:8000`.
+This creates a `production-agents` namespace with the shared gateway accessible at `http://gateway.production-agents.svc.cluster.local:8000`.
 
 ## Complete API Reference
 

--- a/docs/architecture/controllers.md
+++ b/docs/architecture/controllers.md
@@ -71,7 +71,7 @@ The controller assembles configuration from:
 - `AGENT_NAME`, `AGENT_NAMESPACE`, `AGENT_UUID`
 - `AGENT_MODE` - from `spec.executionMode`
 - `AGENT_CLUSTER_NAME`, `AGENT_CLUSTER_UUID`
-- `MODEL_ENDPOINTS` - shared proxy URL (`http://proxy.<namespace>.svc.cluster.local:8000`)
+- `MODEL_ENDPOINTS` - shared gateway URL (`http://gateway.<namespace>.svc.cluster.local:8000`)
 - `LLM_MODEL` - comma-separated list of model names from `models`
 - `MCP_SERVERS` - resolved MCP tool server URLs
 
@@ -90,10 +90,10 @@ The controller assembles configuration from:
 **Creates:**
 
 - Managed namespace for the cluster
-- Shared LiteLLM proxy Deployment (`proxy`)
-- Shared LiteLLM proxy Service (`proxy`)
-- Shared LiteLLM proxy ConfigMap (`proxy-config`)
-- Optional Ingress or HTTPRoute at `proxy.<spec.domain>`
+- Shared LiteLLM gateway Deployment (`gateway`)
+- Shared LiteLLM gateway Service (`gateway`)
+- Shared LiteLLM gateway ConfigMap (`gateway-config`)
+- Optional Ingress or HTTPRoute at `gateway.<spec.domain>`
 
 **Watches:**
 
@@ -105,7 +105,7 @@ The shared proxy is dynamically configured with all `LanguageModel` resources in
 
 **External Access:**
 
-If `spec.domain` is set, the controller creates an Ingress or HTTPRoute (depending on available APIs) to expose the shared proxy externally at `proxy.<domain>`.
+If `spec.domain` is set, the controller creates an Ingress or HTTPRoute (depending on available APIs) to expose the shared gateway externally at `gateway.<domain>`.
 
 ---
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -66,7 +66,7 @@ LLM access is handled by `LanguageModel` CRDs. Each `LanguageCluster` runs a sin
 │                               └──────────────────────────────┘   │
 │  ┌──────────────────────┐    ┌──────────────────────────────┐   │
 │  │    MCP Tool Servers  │    │  Shared LiteLLM Proxy        │   │
-│  │  (LanguageTool CRDs) │    │  proxy.<namespace>.svc:8000  │   │
+│  │  (LanguageTool CRDs) │    │  gateway.<namespace>.svc:8000│   │
 │  └──────────────────────┘    │  (one per LanguageCluster)   │   │
 │                               └──────────────────────────────┘   │
 └─────────────────────────────────────────────────────────────────┘
@@ -209,7 +209,7 @@ The full contract is defined in [Agent Runtime Contract](agents.md). Summary:
 - `/etc/agent/instructions.txt` — plain text task instructions (optional)
 - `/etc/agent/config.yaml` — structured YAML with agent identity, personas, tools, models (optional)
 - Environment variables: `AGENT_NAME`, `AGENT_NAMESPACE`, `AGENT_UUID`, `AGENT_MODE`, `AGENT_CLUSTER_NAME`, `AGENT_CLUSTER_UUID`
-- `MODEL_ENDPOINTS` — URL of the shared LiteLLM proxy (`http://proxy.<namespace>.svc.cluster.local:8000`), injected into main container and all init containers
+- `MODEL_ENDPOINTS` — URL of the shared LiteLLM gateway (`http://gateway.<namespace>.svc.cluster.local:8000`), injected into main container and all init containers
 - `LLM_MODEL` — comma-separated model names registered in the proxy (from all `models`)
 - `MCP_SERVERS` — resolved MCP tool server URLs
 - ClusterIP Service on `spec.port`
@@ -233,7 +233,7 @@ Each `LanguageAgent` gets:
 
 Tool servers (`LanguageTool`) get their own Services. The operator reconciles NetworkPolicy to allow agent pods to reach tool pods.
 
-The shared LiteLLM proxy (`proxy.<namespace>.svc.cluster.local:8000`) is deployed per `LanguageCluster`. NetworkPolicy allows agent pods to reach the proxy, and the proxy has outbound HTTPS egress to upstream model providers.
+The shared LiteLLM gateway (`gateway.<namespace>.svc.cluster.local:8000`) is deployed per `LanguageCluster`. NetworkPolicy allows agent pods to reach the gateway, and the gateway has outbound HTTPS egress to upstream model providers.
 
 ---
 


### PR DESCRIPTION
Closes #348

The `LanguageCluster` controller creates the shared LiteLLM service as `gateway` (not `proxy`). Three doc files still referenced the old name.

**Changes:**
- `docs/architecture/controllers.md`: updated `MODEL_ENDPOINTS` URL, Deployment/Service/ConfigMap names, and external hostname
- `docs/architecture/overview.md`: updated diagram node, `MODEL_ENDPOINTS` description, and Network Architecture section
- `docs/api/languagecluster.md`: updated quick example URL