### PR TITLE
docs: correct webhook URL doc comments to use agent-name not UUID

### DIFF
--- a/chart/templates/crds/langop.io_languageagents.yaml
+++ b/chart/templates/crds/langop.io_languageagents.yaml
@@ -5586,7 +5586,7 @@ spec:
               uuid:
                 description: |-
                   UUID is a unique identifier for this agent instance
-                  Used for webhook routing (e.g., <uuid>.domain.com)
+                  Not used for webhook routing; webhooks are routed via agent name (e.g., <agent-name>.domain.com)
                 type: string
               webhookURLs:
                 description: WebhookURLs contains the URLs where this agent can receive

--- a/chart/templates/crds/langop.io_languageclusters.yaml
+++ b/chart/templates/crds/langop.io_languageclusters.yaml
@@ -98,8 +98,8 @@ spec:
                 description: |-
                   Domain is the base domain for the cluster and agent webhook routing
                   The domain itself serves as the cluster dashboard/UI endpoint
-                  Agent webhooks will be accessible at <uuid>.<domain>
-                  Example: "ai.theryans.io" results in webhooks like "abc123.ai.theryans.io"
+                  Agent webhooks will be accessible at <agent-name>.<domain>
+                  Example: "ai.theryans.io" results in webhooks like "my-agent.ai.theryans.io"
                 type: string
               gateway:
                 description: Gateway configures the shared LiteLLM gateway deployed

--- a/src/api/v1alpha1/languageagent_types.go
+++ b/src/api/v1alpha1/languageagent_types.go
@@ -151,7 +151,7 @@ type LanguageAgentStatus struct {
 	ReadyReplicas int32 `json:"readyReplicas,omitempty"`
 
 	// UUID is a unique identifier for this agent instance
-	// Used for webhook routing (e.g., <uuid>.domain.com)
+	// Not used for webhook routing; webhooks are routed via agent name (e.g., <agent-name>.domain.com)
 	// +optional
 	UUID string `json:"uuid,omitempty"`
 

--- a/src/api/v1alpha1/languagecluster_types.go
+++ b/src/api/v1alpha1/languagecluster_types.go
@@ -72,8 +72,8 @@ type ClusterCapacityStatus struct {
 type LanguageClusterSpec struct {
 	// Domain is the base domain for the cluster and agent webhook routing
 	// The domain itself serves as the cluster dashboard/UI endpoint
-	// Agent webhooks will be accessible at <uuid>.<domain>
-	// Example: "ai.theryans.io" results in webhooks like "abc123.ai.theryans.io"
+	// Agent webhooks will be accessible at <agent-name>.<domain>
+	// Example: "ai.theryans.io" results in webhooks like "my-agent.ai.theryans.io"
 	// +optional
 	Domain string `json:"domain,omitempty"`
 

--- a/src/config/crd/bases/langop.io_languageagents.yaml
+++ b/src/config/crd/bases/langop.io_languageagents.yaml
@@ -5585,7 +5585,7 @@ spec:
               uuid:
                 description: |-
                   UUID is a unique identifier for this agent instance
-                  Used for webhook routing (e.g., <uuid>.domain.com)
+                  Not used for webhook routing; webhooks are routed via agent name (e.g., <agent-name>.domain.com)
                 type: string
               webhookURLs:
                 description: WebhookURLs contains the URLs where this agent can receive

--- a/src/config/crd/bases/langop.io_languageclusters.yaml
+++ b/src/config/crd/bases/langop.io_languageclusters.yaml
@@ -97,8 +97,8 @@ spec:
                 description: |-
                   Domain is the base domain for the cluster and agent webhook routing
                   The domain itself serves as the cluster dashboard/UI endpoint
-                  Agent webhooks will be accessible at <uuid>.<domain>
-                  Example: "ai.theryans.io" results in webhooks like "abc123.ai.theryans.io"
+                  Agent webhooks will be accessible at <agent-name>.<domain>
+                  Example: "ai.theryans.io" results in webhooks like "my-agent.ai.theryans.io"
                 type: string
               gateway:
                 description: Gateway configures the shared LiteLLM gateway deployed


### PR DESCRIPTION
Closes #392