### PR TITLE
feat: discover sidecar LanguageTool schemas via running agent pods

### DIFF
--- a/src/controllers/languagetool_controller.go
+++ b/src/controllers/languagetool_controller.go
@@ -43,6 +43,8 @@ type LanguageToolReconciler struct {
 	Recorder                record.EventRecorder
 	EventManager            *events.EventManager
 	NetworkIsolationEnabled bool
+	// HTTPClient is used for MCP schema discovery requests. When nil, http.DefaultClient is used.
+	HTTPClient *http.Client
 }
 
 // MCPRequest represents an MCP JSON-RPC request
@@ -99,6 +101,7 @@ type MCPSchemaProperty struct {
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop
@@ -278,6 +281,11 @@ func (r *LanguageToolReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	span.SetStatus(codes.Ok, "Reconciliation successful")
+
+	// Requeue sidecar tools that haven't discovered schemas yet — retry once an agent pod is ready
+	if tool.Spec.DeploymentMode == "sidecar" && len(tool.Status.ToolSchemas) == 0 {
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
 	return ctrl.Result{}, nil
 }
 
@@ -579,9 +587,12 @@ func (r *LanguageToolReconciler) reconcileNetworkPolicy(ctx context.Context, too
 func (r *LanguageToolReconciler) discoverMCPToolSchemas(ctx context.Context, endpoint string) ([]langopv1alpha1.ToolSchema, error) {
 	log := log.FromContext(ctx)
 
-	// Create HTTP client with timeout
-	client := &http.Client{
-		Timeout: 10 * time.Second,
+	// Use injected client (for tests) or create a default one
+	client := r.HTTPClient
+	if client == nil {
+		client = &http.Client{
+			Timeout: 10 * time.Second,
+		}
 	}
 
 	// Create MCP tools/list request
@@ -669,14 +680,96 @@ func (r *LanguageToolReconciler) discoverMCPToolSchemas(ctx context.Context, end
 	return schemas, nil
 }
 
+// discoverSidecarSchemas finds a running agent pod that carries this sidecar tool container
+// and queries it for MCP tool schemas. Returns nil schemas (not an error) when no suitable pod
+// is ready yet — the caller should requeue and retry.
+func (r *LanguageToolReconciler) discoverSidecarSchemas(ctx context.Context, tool *langopv1alpha1.LanguageTool) ([]langopv1alpha1.ToolSchema, error) {
+	log := log.FromContext(ctx)
+
+	// Sidecar containers are named "tool-<toolname>" inside agent pods
+	containerName := fmt.Sprintf("tool-%s", tool.Name)
+	port := tool.Spec.Port
+	if port == 0 {
+		port = 8080
+	}
+
+	// List all agent pods in this namespace
+	podList := &corev1.PodList{}
+	if err := r.List(ctx, podList,
+		client.InNamespace(tool.Namespace),
+		client.MatchingLabels{"langop.io/kind": "LanguageAgent"},
+	); err != nil {
+		return nil, fmt.Errorf("failed to list agent pods: %w", err)
+	}
+
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if pod.Status.Phase != corev1.PodRunning || pod.Status.PodIP == "" {
+			continue
+		}
+
+		// Check init containers first (native sidecars run as init containers with restartPolicy=Always)
+		if isSidecarContainerReady(pod.Status.InitContainerStatuses, containerName) {
+			endpoint := fmt.Sprintf("%s:%d", pod.Status.PodIP, port)
+			schemas, err := r.discoverMCPToolSchemas(ctx, endpoint)
+			if err != nil {
+				log.Error(err, "Failed to discover sidecar schemas via agent pod", "pod", pod.Name, "endpoint", endpoint)
+				continue
+			}
+			log.Info("Discovered sidecar schemas via agent pod", "pod", pod.Name, "toolCount", len(schemas))
+			return schemas, nil
+		}
+
+		// Also check regular containers for compatibility
+		if isSidecarContainerReady(pod.Status.ContainerStatuses, containerName) {
+			endpoint := fmt.Sprintf("%s:%d", pod.Status.PodIP, port)
+			schemas, err := r.discoverMCPToolSchemas(ctx, endpoint)
+			if err != nil {
+				log.Error(err, "Failed to discover sidecar schemas via agent pod", "pod", pod.Name, "endpoint", endpoint)
+				continue
+			}
+			log.Info("Discovered sidecar schemas via agent pod", "pod", pod.Name, "toolCount", len(schemas))
+			return schemas, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// isSidecarContainerReady returns true if a container with the given name is ready in the status slice.
+func isSidecarContainerReady(statuses []corev1.ContainerStatus, name string) bool {
+	for _, cs := range statuses {
+		if cs.Name == name {
+			return cs.Ready
+		}
+	}
+	return false
+}
+
 func (r *LanguageToolReconciler) updateToolStatus(ctx context.Context, tool *langopv1alpha1.LanguageTool) error {
-	// For sidecar mode tools, just set as ready (no deployment to check)
+	// For sidecar mode tools, discover schemas from a running agent pod
 	if tool.Spec.DeploymentMode == "sidecar" {
 		tool.Status.Phase = events.PhaseStatusRunning
 		SetCondition(&tool.Status.Conditions, "Ready", metav1.ConditionTrue, "ReconcileSuccess", "LanguageTool is ready", tool.Generation)
 
-		// Note: Sidecar tools don't have a service endpoint, so we can't discover schemas
-		// Schemas will be populated from agent runtime when the sidecar is used
+		schemas, err := r.discoverSidecarSchemas(ctx, tool)
+		if err != nil {
+			// Log but don't fail — tool is still injected even without cached schemas
+			log := log.FromContext(ctx)
+			log.Error(err, "Failed to discover sidecar schemas", "tool", tool.Name)
+		}
+
+		if len(schemas) > 0 {
+			tool.Status.ToolSchemas = schemas
+			var toolNames []string
+			for _, s := range schemas {
+				toolNames = append(toolNames, s.Name)
+			}
+			tool.Status.AvailableTools = toolNames
+			SetCondition(&tool.Status.Conditions, "SchemasDiscovered", metav1.ConditionTrue, "SchemasDiscovered", "Tool schemas discovered from running agent pod", tool.Generation)
+		} else {
+			SetCondition(&tool.Status.Conditions, "SchemasDiscovered", metav1.ConditionFalse, "NoRunningAgentPod", "No running agent pod with this sidecar found; schemas will populate once an agent pod is ready", tool.Generation)
+		}
 
 		return r.Status().Update(ctx, tool)
 	}

--- a/src/controllers/languagetool_controller_test.go
+++ b/src/controllers/languagetool_controller_test.go
@@ -2,10 +2,14 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
-	"fmt"
 	langopv1alpha1 "github.com/language-operator/language-operator/api/v1alpha1"
 	"github.com/language-operator/language-operator/controllers/testutil"
 	"github.com/language-operator/language-operator/internal/testutil/gen"
@@ -958,5 +962,177 @@ func TestLanguageToolController_Deletion(t *testing.T) {
 				t.Error("Expected finalizer to be removed after deletion")
 			}
 		}
+	}
+}
+
+func TestLanguageToolController_SidecarMode_NoRunningPod(t *testing.T) {
+	scheme := testutil.SetupTestScheme(t)
+
+	tool := gen.LanguageTool("my-sidecar-tool", "default",
+		gen.SetToolImage("ghcr.io/test/tool:latest"),
+		gen.SetToolDeploymentMode("sidecar"),
+		gen.SetToolPort(8080),
+	)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gen.ReadyCluster("default"), tool).
+		WithStatusSubresource(tool).
+		Build()
+
+	reconciler := &LanguageToolReconciler{
+		Client:          fakeClient,
+		Scheme:          scheme,
+		RegistryManager: &mockRegistryManager{},
+	}
+
+	ctx := context.Background()
+	result, err := reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: tool.Name, Namespace: tool.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	// Should requeue because no pod is available yet
+	if result.RequeueAfter == 0 {
+		t.Error("Expected non-zero RequeueAfter when no agent pod is running")
+	}
+
+	updatedTool := &langopv1alpha1.LanguageTool{}
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: tool.Name, Namespace: tool.Namespace}, updatedTool); err != nil {
+		t.Fatalf("Failed to get updated tool: %v", err)
+	}
+
+	// AvailableTools and ToolSchemas should be empty
+	if len(updatedTool.Status.AvailableTools) != 0 {
+		t.Errorf("Expected no AvailableTools, got %v", updatedTool.Status.AvailableTools)
+	}
+	if len(updatedTool.Status.ToolSchemas) != 0 {
+		t.Errorf("Expected no ToolSchemas, got %v", updatedTool.Status.ToolSchemas)
+	}
+
+	// SchemasDiscovered condition should be False with reason NoRunningAgentPod
+	var schemasCond *metav1.Condition
+	for i := range updatedTool.Status.Conditions {
+		if updatedTool.Status.Conditions[i].Type == "SchemasDiscovered" {
+			schemasCond = &updatedTool.Status.Conditions[i]
+			break
+		}
+	}
+	if schemasCond == nil {
+		t.Fatal("Expected SchemasDiscovered condition to be set")
+	}
+	if schemasCond.Status != metav1.ConditionFalse {
+		t.Errorf("Expected SchemasDiscovered=False, got %s", schemasCond.Status)
+	}
+	if schemasCond.Reason != "NoRunningAgentPod" {
+		t.Errorf("Expected reason NoRunningAgentPod, got %s", schemasCond.Reason)
+	}
+}
+
+func TestLanguageToolController_SidecarMode_SchemasDiscoveredViaPod(t *testing.T) {
+	scheme := testutil.SetupTestScheme(t)
+
+	// Start a mock MCP server that returns two tools
+	mcpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := MCPResponse{
+			JSONRpc: "2.0",
+			ID:      1,
+			Result: json.RawMessage(`{"tools":[
+				{"name":"read_file","description":"Read a file"},
+				{"name":"write_file","description":"Write a file"}
+			]}`),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer mcpServer.Close()
+
+	// The fake pod's IP must match what discoverSidecarSchemas will query.
+	// We use the httptest server's host:port as the pod IP:port combo by pointing the
+	// pod IP to 127.0.0.1 and using the server's port.
+	serverHost := mcpServer.Listener.Addr().(*net.TCPAddr).IP.String()
+	serverPort := int32(mcpServer.Listener.Addr().(*net.TCPAddr).Port)
+
+	tool := gen.LanguageTool("my-sidecar-tool", "default",
+		gen.SetToolImage("ghcr.io/test/tool:latest"),
+		gen.SetToolDeploymentMode("sidecar"),
+		gen.SetToolPort(serverPort),
+	)
+
+	// Create a running agent pod with the sidecar container ready
+	agentPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "agent-pod-1",
+			Namespace: "default",
+			Labels: map[string]string{
+				"langop.io/kind": "LanguageAgent",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: serverHost,
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  fmt.Sprintf("tool-%s", tool.Name),
+					Ready: true,
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gen.ReadyCluster("default"), tool, agentPod).
+		WithStatusSubresource(tool).
+		Build()
+
+	reconciler := &LanguageToolReconciler{
+		Client:          fakeClient,
+		Scheme:          scheme,
+		RegistryManager: &mockRegistryManager{},
+		// Use the test server's transport so requests reach the httptest server
+		HTTPClient: mcpServer.Client(),
+	}
+
+	ctx := context.Background()
+	result, err := reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: tool.Name, Namespace: tool.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	// Should NOT requeue because schemas were discovered
+	if result.RequeueAfter != 0 {
+		t.Errorf("Expected zero RequeueAfter after successful schema discovery, got %v", result.RequeueAfter)
+	}
+
+	updatedTool := &langopv1alpha1.LanguageTool{}
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: tool.Name, Namespace: tool.Namespace}, updatedTool); err != nil {
+		t.Fatalf("Failed to get updated tool: %v", err)
+	}
+
+	if len(updatedTool.Status.AvailableTools) != 2 {
+		t.Errorf("Expected 2 AvailableTools, got %v", updatedTool.Status.AvailableTools)
+	}
+	if len(updatedTool.Status.ToolSchemas) != 2 {
+		t.Errorf("Expected 2 ToolSchemas, got %v", updatedTool.Status.ToolSchemas)
+	}
+
+	// SchemasDiscovered condition should be True
+	var schemasCond *metav1.Condition
+	for i := range updatedTool.Status.Conditions {
+		if updatedTool.Status.Conditions[i].Type == "SchemasDiscovered" {
+			schemasCond = &updatedTool.Status.Conditions[i]
+			break
+		}
+	}
+	if schemasCond == nil {
+		t.Fatal("Expected SchemasDiscovered condition to be set")
+	}
+	if schemasCond.Status != metav1.ConditionTrue {
+		t.Errorf("Expected SchemasDiscovered=True, got %s", schemasCond.Status)
 	}
 }


### PR DESCRIPTION
Closes #419

## Summary

- Adds `discoverSidecarSchemas` to `LanguageToolReconciler` which lists running agent pods (`langop.io/kind=LanguageAgent`) and finds the first pod with the `tool-<name>` sidecar container ready, then queries it via `discoverMCPToolSchemas`
- Populates `status.availableTools` + `status.toolSchemas` when discovery succeeds; sets `SchemasDiscovered=False/NoRunningAgentPod` condition when no pod is ready yet
- Adds `HTTPClient *http.Client` field for test injection (nil → DefaultClient)
- Reconciler requeues after 30 s while schemas are pending
- New RBAC: `pods: get;list;watch`

## Tests

- `TestLanguageToolController_SidecarMode_NoRunningPod` — no agent pods → `SchemasDiscovered=False`, non-zero RequeueAfter
- `TestLanguageToolController_SidecarMode_SchemasDiscoveredViaPod` — running pod with ready sidecar container + httptest server → schemas populated, zero RequeueAfter