### PR TITLE
fix: remove stale batchv1.Job comment from LanguageAgent Reconcile

### DIFF
--- a/src/controllers/languageagent_controller.go
+++ b/src/controllers/languageagent_controller.go
@@ -404,8 +404,8 @@ func (r *LanguageAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Reconciliation successful
 	span.SetStatus(codes.Ok, "Reconciliation successful")
 
-	// No need for periodic requeues - Job events will trigger reconciliation automatically
-	// via the Owns(&batchv1.Job{}) watch relationship in SetupWithManager
+	// No need for periodic requeues - owner-reference events from Deployment, Service, ConfigMap,
+	// and other owned resources drive re-reconciliation via SetupWithManager watches.
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
Closes #415

Replaces the misleading comment referencing a non-existent `batchv1.Job` watch with an accurate description of how re-reconciliation is driven by owner-reference events from Deployment, Service, ConfigMap, and other owned resources.