### PR TITLE
fix: remove stray kubebuilder markers above const block in languageagent_types.go

### DIFF
--- a/src/api/v1alpha1/languageagent_types.go
+++ b/src/api/v1alpha1/languageagent_types.go
@@ -160,8 +160,6 @@ type LanguageAgentStatus struct {
 	WebhookURLs []string `json:"webhookURLs,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
 // Condition types for LanguageAgent
 const (
 	// WebhookRouteCreatedCondition indicates that the webhook Ingress has been created


### PR DESCRIPTION
Closes #423