### PR TITLE
fix: handle ms/ns/us/µs suffixes in generate-config.py timeout parser

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,6 +82,24 @@ jobs:
           KUBEBUILDER_ASSETS="$(setup-envtest use 1.29.0 -p path)" \
             go test -tags integration -v -timeout 120s ./...
 
+  # Run Python component tests
+  python-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install test dependencies
+        run: pip install pytest pyyaml
+
+      - name: Run Python tests
+        run: pytest components/model/test_generate_config.py -v
+
   # Validate CRD manifests
   validate-manifests:
     runs-on: ubuntu-latest

--- a/components/model/generate-config.py
+++ b/components/model/generate-config.py
@@ -91,6 +91,30 @@ def map_provider_to_litellm(provider: str, model_name: str, endpoint: Optional[s
     return provider_map.get(provider, model_name)
 
 
+def parse_duration_to_seconds(timeout_str: str) -> float:
+    """Parse a Go-style duration string to seconds.
+
+    Supported suffixes (checked longest-first to avoid prefix collisions):
+      ns, us, µs, ms, s, m, h
+    Unknown suffixes return the default of 300.0 seconds.
+    """
+    if timeout_str.endswith("ms"):
+        return float(timeout_str[:-2]) / 1_000
+    elif timeout_str.endswith("ns"):
+        return float(timeout_str[:-2]) / 1_000_000_000
+    elif timeout_str.endswith("µs"):
+        return float(timeout_str[:-2]) / 1_000_000
+    elif timeout_str.endswith("us"):
+        return float(timeout_str[:-2]) / 1_000_000
+    elif timeout_str.endswith("h"):
+        return float(timeout_str[:-1]) * 3600
+    elif timeout_str.endswith("m"):
+        return float(timeout_str[:-1]) * 60
+    elif timeout_str.endswith("s"):
+        return float(timeout_str[:-1])
+    return 300.0  # default 5 minutes
+
+
 def build_litellm_params(spec: Dict[str, Any], api_key: Optional[str]) -> Dict[str, Any]:
     """Build litellm_params from LanguageModel spec."""
     params: Dict[str, Any] = {}
@@ -123,17 +147,7 @@ def build_litellm_params(spec: Dict[str, Any], api_key: Optional[str]) -> Dict[s
 
     # Add timeout
     if spec.get("timeout"):
-        # Parse duration like "5m" or "30s" to seconds
-        timeout_str = spec["timeout"]
-        if timeout_str.endswith("m"):
-            timeout = int(timeout_str[:-1]) * 60
-        elif timeout_str.endswith("s"):
-            timeout = int(timeout_str[:-1])
-        elif timeout_str.endswith("h"):
-            timeout = int(timeout_str[:-1]) * 3600
-        else:
-            timeout = 300  # default 5 minutes
-        params["timeout"] = timeout
+        params["timeout"] = parse_duration_to_seconds(spec["timeout"])
 
     return params
 

--- a/components/model/test_generate_config.py
+++ b/components/model/test_generate_config.py
@@ -1,0 +1,102 @@
+"""Tests for generate-config.py — focused on the timeout duration parser."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load generate-config.py as a module (hyphen in filename requires importlib)
+_spec = importlib.util.spec_from_file_location(
+    "generate_config",
+    Path(__file__).parent / "generate-config.py",
+)
+generate_config = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(generate_config)
+
+parse_duration_to_seconds = generate_config.parse_duration_to_seconds
+build_litellm_params = generate_config.build_litellm_params
+
+
+class TestParseDurationToSeconds:
+    def test_seconds(self):
+        assert parse_duration_to_seconds("30s") == 30.0
+
+    def test_minutes(self):
+        assert parse_duration_to_seconds("5m") == 300.0
+
+    def test_hours(self):
+        assert parse_duration_to_seconds("2h") == 7200.0
+
+    def test_milliseconds(self):
+        assert parse_duration_to_seconds("500ms") == pytest.approx(0.5)
+
+    def test_nanoseconds(self):
+        assert parse_duration_to_seconds("1000000000ns") == pytest.approx(1.0)
+
+    def test_microseconds_us(self):
+        assert parse_duration_to_seconds("1000000us") == pytest.approx(1.0)
+
+    def test_microseconds_unicode(self):
+        assert parse_duration_to_seconds("1000000µs") == pytest.approx(1.0)
+
+    def test_unknown_suffix_returns_default(self):
+        assert parse_duration_to_seconds("10x") == 300.0
+
+    def test_ms_does_not_match_s_branch(self):
+        # 500ms should NOT be parsed as int("500m") seconds — that would ValueError
+        result = parse_duration_to_seconds("500ms")
+        assert result == pytest.approx(0.5)
+
+    def test_ns_does_not_match_s_branch(self):
+        result = parse_duration_to_seconds("100ns")
+        assert result == pytest.approx(1e-7)
+
+    def test_us_does_not_match_s_branch(self):
+        result = parse_duration_to_seconds("50us")
+        assert result == pytest.approx(5e-5)
+
+    def test_fractional_seconds(self):
+        assert parse_duration_to_seconds("1s") == 1.0
+
+    def test_large_hours(self):
+        assert parse_duration_to_seconds("24h") == pytest.approx(86400.0)
+
+
+class TestBuildLitellmParamsTimeout:
+    """Verify build_litellm_params passes timeout correctly for every suffix."""
+
+    BASE_SPEC = {
+        "provider": "openai",
+        "modelName": "gpt-4",
+    }
+
+    def _params(self, timeout: str):
+        spec = {**self.BASE_SPEC, "timeout": timeout}
+        return build_litellm_params(spec, api_key=None)
+
+    def test_timeout_s(self):
+        assert self._params("30s")["timeout"] == 30.0
+
+    def test_timeout_m(self):
+        assert self._params("5m")["timeout"] == 300.0
+
+    def test_timeout_h(self):
+        assert self._params("1h")["timeout"] == 3600.0
+
+    def test_timeout_ms(self):
+        assert self._params("500ms")["timeout"] == pytest.approx(0.5)
+
+    def test_timeout_ns(self):
+        assert self._params("1000000000ns")["timeout"] == pytest.approx(1.0)
+
+    def test_timeout_us(self):
+        assert self._params("1000000us")["timeout"] == pytest.approx(1.0)
+
+    def test_timeout_unicode_us(self):
+        assert self._params("1000000µs")["timeout"] == pytest.approx(1.0)
+
+    def test_no_timeout_omitted(self):
+        spec = {**self.BASE_SPEC}
+        params = build_litellm_params(spec, api_key=None)
+        assert "timeout" not in params


### PR DESCRIPTION
Closes #425