### PR TITLE
fix: log status update errors in LanguageTool error paths

### DIFF
--- a/src/controllers/languagetool_controller.go
+++ b/src/controllers/languagetool_controller.go
@@ -209,7 +209,9 @@ func (r *LanguageToolReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			}
 			SetCondition(&tool.Status.Conditions, langopv1alpha1.ConditionReady, metav1.ConditionFalse, "DeploymentError", err.Error(), tool.Generation)
 			tool.Status.Phase = events.PhaseStatusFailed
-			r.Status().Update(ctx, tool)
+			if updateErr := r.Status().Update(ctx, tool); updateErr != nil {
+				log.Error(updateErr, "Failed to update status after Deployment failure")
+			}
 			reconcileErr = err
 			return ctrl.Result{}, err
 		}
@@ -224,7 +226,9 @@ func (r *LanguageToolReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			}
 			SetCondition(&tool.Status.Conditions, langopv1alpha1.ConditionReady, metav1.ConditionFalse, "ServiceError", err.Error(), tool.Generation)
 			tool.Status.Phase = events.PhaseStatusFailed
-			r.Status().Update(ctx, tool)
+			if updateErr := r.Status().Update(ctx, tool); updateErr != nil {
+				log.Error(updateErr, "Failed to update status after Service failure")
+			}
 			reconcileErr = err
 			return ctrl.Result{}, err
 		}
@@ -241,7 +245,9 @@ func (r *LanguageToolReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			}
 			SetCondition(&tool.Status.Conditions, langopv1alpha1.ConditionReady, metav1.ConditionFalse, "NetworkPolicyError", err.Error(), tool.Generation)
 			tool.Status.Phase = events.PhaseStatusFailed
-			r.Status().Update(ctx, tool)
+			if updateErr := r.Status().Update(ctx, tool); updateErr != nil {
+				log.Error(updateErr, "Failed to update status after NetworkPolicy failure")
+			}
 			reconcileErr = err
 			return ctrl.Result{}, err
 		} else {


### PR DESCRIPTION
Closes #441

Four error paths in `languagetool_controller.go` were calling `r.Status().Update()` without capturing the return value, silently swallowing status update failures (resource version conflicts, stale cache reads). Wrapped each with the standard `if updateErr := ...; updateErr != nil { log.Error(...) }` pattern used consistently across all other controllers.