### PR TITLE
fix: replace ClusterRoleBinding with Role+RoleBinding and add RBAC cleanup on agent deletion

### DIFF
--- a/src/controllers/languageagent_controller.go
+++ b/src/controllers/languageagent_controller.go
@@ -1213,6 +1213,12 @@ func (r *LanguageAgentReconciler) cleanupResources(ctx context.Context, agent *l
 		log.Error(err, "Failed to cleanup Services", "agent", agent.Name)
 	}
 
+	// 3. Cleanup shared RBAC resources if this is the last agent in the namespace
+	if err := r.cleanupSharedRBAC(cleanupCtx, agent); err != nil {
+		cleanupErrors = append(cleanupErrors, fmt.Errorf("RBAC cleanup failed: %w", err))
+		log.Error(err, "Failed to cleanup RBAC resources", "agent", agent.Name)
+	}
+
 	// Log summary
 	if len(cleanupErrors) == 0 {
 		log.Info("Resource cleanup completed successfully", "agent", agent.Name)
@@ -1280,6 +1286,39 @@ func (r *LanguageAgentReconciler) cleanupServices(ctx context.Context, agent *la
 		log.Info("Successfully deleted Service", "name", service.Name, "namespace", service.Namespace)
 	}
 
+	return nil
+}
+
+// cleanupSharedRBAC deletes the shared ServiceAccount, Role, and RoleBinding for agent pods
+// in the given namespace, but only when no other LanguageAgents remain in that namespace.
+func (r *LanguageAgentReconciler) cleanupSharedRBAC(ctx context.Context, agent *langopv1alpha1.LanguageAgent) error {
+	log := log.FromContext(ctx)
+	ns := agent.Namespace
+
+	// Check whether any other agents remain in this namespace
+	agentList := &langopv1alpha1.LanguageAgentList{}
+	if err := r.List(ctx, agentList, client.InNamespace(ns)); err != nil {
+		return fmt.Errorf("failed to list LanguageAgents: %w", err)
+	}
+	for _, a := range agentList.Items {
+		if a.Name != agent.Name {
+			// Another agent still exists; leave shared resources intact
+			return nil
+		}
+	}
+
+	// Last agent in namespace — delete shared RBAC resources
+	toDelete := []client.Object{
+		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "language-agent", Namespace: ns}},
+		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "language-agent", Namespace: ns}},
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "language-agent", Namespace: ns}},
+	}
+	for _, obj := range toDelete {
+		if err := r.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete %T %s: %w", obj, "language-agent", err)
+		}
+		log.Info("Deleted shared RBAC resource", "kind", fmt.Sprintf("%T", obj), "namespace", ns)
+	}
 	return nil
 }
 
@@ -1631,8 +1670,6 @@ func (r *LanguageAgentReconciler) SetupWithManager(mgr ctrl.Manager, concurrency
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Service{}).
-		Owns(&corev1.ServiceAccount{}).
-		Owns(&rbacv1.ClusterRoleBinding{}).
 		Owns(&networkingv1.NetworkPolicy{}).
 		Owns(&networkingv1.Ingress{}).
 		Complete(r)
@@ -1674,49 +1711,88 @@ func (r *LanguageAgentReconciler) reconcileAgentServiceAccount(ctx context.Conte
 		return fmt.Errorf("failed to create/update ServiceAccount: %w", err)
 	}
 
-	// Create ClusterRoleBinding to give the ServiceAccount permissions
-	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+	// Delete legacy ClusterRoleBinding if present (migration cleanup)
+	legacyCRBName := fmt.Sprintf("language-agent-%s-language-agent", targetNamespace)
+	legacyCRB := &rbacv1.ClusterRoleBinding{}
+	if err := r.Get(ctx, types.NamespacedName{Name: legacyCRBName}, legacyCRB); err == nil {
+		if err := r.Delete(ctx, legacyCRB); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete legacy ClusterRoleBinding: %w", err)
+		}
+	}
+
+	// Create namespace-scoped Role with minimal permissions for agent pods
+	role := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("language-agent-%s-%s", targetNamespace, "language-agent"),
+			Name:      "language-agent",
+			Namespace: targetNamespace,
 		},
 	}
 
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, clusterRoleBinding, func() error {
-		// Set labels
-		if clusterRoleBinding.Labels == nil {
-			clusterRoleBinding.Labels = make(map[string]string)
+	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, role, func() error {
+		if role.Labels == nil {
+			role.Labels = make(map[string]string)
 		}
-		clusterRoleBinding.Labels["app.kubernetes.io/name"] = "language-agent"
-		clusterRoleBinding.Labels["app.kubernetes.io/component"] = "clusterrolebinding"
-		clusterRoleBinding.Labels["app.kubernetes.io/managed-by"] = "language-operator"
+		role.Labels["app.kubernetes.io/name"] = "language-agent"
+		role.Labels["app.kubernetes.io/component"] = "role"
+		role.Labels["app.kubernetes.io/managed-by"] = "language-operator"
+		role.Rules = []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"configmaps"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+		}
+		return nil
+	})
 
-		// Bind to the language-operator ClusterRole which has the necessary permissions
-		clusterRoleBinding.RoleRef = rbacv1.RoleRef{
+	if err != nil {
+		return fmt.Errorf("failed to create/update Role: %w", err)
+	}
+
+	// Create namespace-scoped RoleBinding binding the ServiceAccount to the Role
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "language-agent",
+			Namespace: targetNamespace,
+		},
+	}
+
+	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, roleBinding, func() error {
+		if roleBinding.Labels == nil {
+			roleBinding.Labels = make(map[string]string)
+		}
+		roleBinding.Labels["app.kubernetes.io/name"] = "language-agent"
+		roleBinding.Labels["app.kubernetes.io/component"] = "rolebinding"
+		roleBinding.Labels["app.kubernetes.io/managed-by"] = "language-operator"
+		roleBinding.RoleRef = rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
-			Name:     "language-operator",
+			Kind:     "Role",
+			Name:     "language-agent",
 		}
-
-		// Subject is the ServiceAccount in the target namespace
-		clusterRoleBinding.Subjects = []rbacv1.Subject{
+		roleBinding.Subjects = []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
 				Name:      "language-agent",
 				Namespace: targetNamespace,
 			},
 		}
-
 		return nil
 	})
 
 	if err != nil {
-		return fmt.Errorf("failed to create/update ClusterRoleBinding: %w", err)
+		return fmt.Errorf("failed to create/update RoleBinding: %w", err)
 	}
 
 	log.Info("Reconciled agent ServiceAccount and permissions",
 		"serviceAccount", "language-agent",
 		"namespace", targetNamespace,
-		"clusterRoleBinding", clusterRoleBinding.Name)
+		"role", role.Name,
+		"roleBinding", roleBinding.Name)
 
 	return nil
 }

--- a/src/controllers/languageagent_controller_test.go
+++ b/src/controllers/languageagent_controller_test.go
@@ -1258,14 +1258,25 @@ func TestLanguageAgentController_ServiceAccountCreation(t *testing.T) {
 		t.Fatalf("Expected ServiceAccount 'language-agent' to exist in namespace %s: %v", agent.Namespace, err)
 	}
 
-	// Verify ClusterRoleBinding created
-	crb := &rbacv1.ClusterRoleBinding{}
-	crbName := "language-agent-" + agent.Namespace + "-language-agent"
-	if err := fakeClient.Get(ctx, types.NamespacedName{Name: crbName}, crb); err != nil {
-		t.Fatalf("Expected ClusterRoleBinding %q to exist: %v", crbName, err)
+	// Verify namespace-scoped Role created
+	role := &rbacv1.Role{}
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: "language-agent", Namespace: agent.Namespace}, role); err != nil {
+		t.Fatalf("Expected Role 'language-agent' to exist in namespace %s: %v", agent.Namespace, err)
 	}
-	if crb.RoleRef.Name != "language-operator" {
-		t.Errorf("Expected ClusterRoleBinding to reference 'language-operator' ClusterRole, got %q", crb.RoleRef.Name)
+	if len(role.Rules) == 0 {
+		t.Errorf("Expected Role to have at least one rule")
+	}
+
+	// Verify namespace-scoped RoleBinding created and points to the Role (not the operator ClusterRole)
+	rb := &rbacv1.RoleBinding{}
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: "language-agent", Namespace: agent.Namespace}, rb); err != nil {
+		t.Fatalf("Expected RoleBinding 'language-agent' to exist in namespace %s: %v", agent.Namespace, err)
+	}
+	if rb.RoleRef.Kind != "Role" {
+		t.Errorf("Expected RoleBinding RoleRef.Kind 'Role', got %q", rb.RoleRef.Kind)
+	}
+	if rb.RoleRef.Name != "language-agent" {
+		t.Errorf("Expected RoleBinding RoleRef.Name 'language-agent', got %q", rb.RoleRef.Name)
 	}
 }
 


### PR DESCRIPTION
Closes #440

## Summary
- Replaces the cluster-scoped `ClusterRoleBinding` (binding agent pods to the operator's own `language-operator` ClusterRole) with a namespace-scoped `Role` + `RoleBinding` giving agents minimal read-only access (`configmaps: get/list`, `pods: get/list/watch`)
- Removes dead `Owns(&corev1.ServiceAccount{})` and `Owns(&rbacv1.ClusterRoleBinding{})` from `SetupWithManager` — neither resource had owner references set, so these watches never fired
- Adds `cleanupSharedRBAC` called from `cleanupResources` to delete the SA, Role, and RoleBinding when the last agent in a namespace is deleted
- Adds migration cleanup: deletes legacy `ClusterRoleBinding` named `language-agent-{namespace}-language-agent` on next reconcile of any existing agent