### PR TITLE
fix: bound DNS lookups in reconcile path with per-lookup timeout and generation gating

### DIFF
--- a/src/controllers/languagecluster_controller.go
+++ b/src/controllers/languagecluster_controller.go
@@ -587,7 +587,7 @@ func (r *LanguageClusterReconciler) reconcileNetworkPolicy(ctx context.Context, 
 
 			// Resolve DNS hostnames to CIDR blocks at policy creation time (fail-closed)
 			if len(rule.To.DNS) > 0 {
-				resolvedCIDRs, err := resolveDNSToCIDRs(rule.To.DNS)
+				resolvedCIDRs, err := resolveDNSToCIDRs(ctx, rule.To.DNS)
 				if err == nil && len(resolvedCIDRs) > 0 {
 					for _, cidr := range resolvedCIDRs {
 						egressRule.To = append(egressRule.To, networkingv1.NetworkPolicyPeer{
@@ -796,6 +796,19 @@ func (r *LanguageClusterReconciler) validateDNS(ctx context.Context, cluster *la
 	}
 
 	domain := cluster.Spec.Domain
+
+	// Skip DNS lookup if the condition already reflects the current generation.
+	// This prevents blocking the reconcile worker on every loop for clusters
+	// whose domain has not changed.
+	for _, cond := range cluster.Status.Conditions {
+		if cond.Type == langopv1alpha1.ConditionDNSConfigured &&
+			cond.ObservedGeneration == cluster.Generation {
+			log.V(1).Info("DNS condition up-to-date for current generation, skipping lookup",
+				"domain", domain, "generation", cluster.Generation)
+			return
+		}
+	}
+
 	log.V(1).Info("Validating DNS configuration", "domain", domain)
 
 	// Test DNS resolution with a test subdomain

--- a/src/controllers/languagecluster_controller_test.go
+++ b/src/controllers/languagecluster_controller_test.go
@@ -1454,3 +1454,55 @@ func TestLanguageClusterController_GatewayVolumesAndMounts(t *testing.T) {
 	assert.Contains(t, mountPaths, "/etc/langop/models", "operator-managed mount must be retained")
 	assert.Contains(t, mountPaths, "/etc/ssl/custom", "user mount must be appended")
 }
+
+// TestValidateDNS_SkipsOnSameGeneration verifies that validateDNS does not perform
+// a DNS lookup (and does not modify the condition) when the DNSConfigured condition
+// already reflects the current resource generation.
+func TestValidateDNS_SkipsOnSameGeneration(t *testing.T) {
+	scheme := testutil.SetupTestScheme(t)
+
+	cluster := gen.LanguageCluster("skip-dns",
+		gen.SetClusterDomain("example.com"),
+	)
+	cluster.Generation = 3
+
+	// Pre-populate a DNSConfigured condition for the current generation.
+	existingCondition := metav1.Condition{
+		Type:               langopv1alpha1.ConditionDNSConfigured,
+		Status:             metav1.ConditionTrue,
+		Reason:             "WildcardDNSReady",
+		Message:            "already validated",
+		ObservedGeneration: 3,
+		LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * time.Minute)),
+	}
+	cluster.Status.Conditions = []metav1.Condition{existingCondition}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster).
+		WithStatusSubresource(cluster).
+		Build()
+
+	reconciler := &LanguageClusterReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+		Log:    logr.Discard(),
+	}
+
+	reconciler.validateDNS(context.Background(), cluster)
+
+	// Condition must be unchanged — same content and same LastTransitionTime.
+	var found *metav1.Condition
+	for i := range cluster.Status.Conditions {
+		if cluster.Status.Conditions[i].Type == langopv1alpha1.ConditionDNSConfigured {
+			found = &cluster.Status.Conditions[i]
+			break
+		}
+	}
+	require.NotNil(t, found)
+	assert.Equal(t, existingCondition.Status, found.Status)
+	assert.Equal(t, existingCondition.Reason, found.Reason)
+	assert.Equal(t, existingCondition.ObservedGeneration, found.ObservedGeneration)
+	assert.Equal(t, existingCondition.LastTransitionTime, found.LastTransitionTime,
+		"LastTransitionTime must not change when DNS lookup is skipped")
+}

--- a/src/controllers/utils.go
+++ b/src/controllers/utils.go
@@ -327,7 +327,9 @@ func GetCommonLabels(resourceName, resourceKind string) map[string]string {
 // resolveDNSToCIDRs resolves DNS hostnames to IP addresses and returns CIDR blocks
 // Supports wildcards: *.example.com will resolve example.com and cache the result
 // Special case: "*" means allow all destinations (0.0.0.0/0)
-func resolveDNSToCIDRs(dnsNames []string) ([]string, error) {
+// Each lookup is bounded by a 3-second per-host timeout derived from ctx to avoid stalling
+// the reconcile worker goroutine.
+func resolveDNSToCIDRs(ctx context.Context, dnsNames []string) ([]string, error) {
 	var cidrs []string
 	seenIPs := make(map[string]bool)
 
@@ -345,8 +347,11 @@ func resolveDNSToCIDRs(dnsNames []string) ([]string, error) {
 			resolveHostname = hostname[2:] // Remove *.
 		}
 
-		// Resolve the hostname to IP addresses
-		ips, err := net.LookupIP(resolveHostname)
+		// Resolve the hostname to IP addresses with a per-lookup timeout so a
+		// slow or unreachable DNS server cannot stall the reconcile worker.
+		lookupCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		addrs, err := (&net.Resolver{}).LookupIPAddr(lookupCtx, resolveHostname)
+		cancel()
 		if err != nil {
 			// Don't fail the entire policy if one DNS lookup fails
 			// Log and continue
@@ -354,7 +359,8 @@ func resolveDNSToCIDRs(dnsNames []string) ([]string, error) {
 		}
 
 		// Convert IPs to /32 (IPv4) or /128 (IPv6) CIDR blocks
-		for _, ip := range ips {
+		for _, addr := range addrs {
+			ip := addr.IP
 			var cidr string
 			if ip.To4() != nil {
 				cidr = ip.String() + "/32"
@@ -514,7 +520,7 @@ func BuildEgressNetworkPolicy(
 		// Note: DNS records can change, so this is a point-in-time resolution
 		// Policies will be updated on the next reconciliation loop
 		if len(rule.To.DNS) > 0 {
-			resolvedCIDRs, err := resolveDNSToCIDRs(rule.To.DNS)
+			resolvedCIDRs, err := resolveDNSToCIDRs(ctx, rule.To.DNS)
 			if err == nil && len(resolvedCIDRs) > 0 {
 				for _, cidr := range resolvedCIDRs {
 					policyRule.To = append(policyRule.To, networkingv1.NetworkPolicyPeer{

--- a/src/controllers/utils_test.go
+++ b/src/controllers/utils_test.go
@@ -275,3 +275,26 @@ func TestBuildEgressNetworkPolicy_NoFromRule_NoPolicyTypeIngress(t *testing.T) {
 	}
 	assert.Empty(t, policy.Spec.Ingress)
 }
+
+// TestResolveDNSToCIDRs_ContextTimeout verifies that a cancelled context causes
+// resolveDNSToCIDRs to return an empty slice immediately rather than blocking.
+func TestResolveDNSToCIDRs_ContextTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel so every lookup sees a done context
+
+	cidrs, err := resolveDNSToCIDRs(ctx, []string{"api.example.com", "*.example.org"})
+	require.NoError(t, err)
+	assert.Empty(t, cidrs, "cancelled context should produce no CIDRs")
+}
+
+// TestResolveDNSToCIDRs_WildcardAll verifies that "*" still returns 0.0.0.0/0
+// even when the context is cancelled.
+func TestResolveDNSToCIDRs_WildcardAll(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cidrs, err := resolveDNSToCIDRs(ctx, []string{"*"})
+	require.NoError(t, err)
+	require.Len(t, cidrs, 1)
+	assert.Equal(t, "0.0.0.0/0", cidrs[0])
+}


### PR DESCRIPTION
Closes #449

## Changes

### `resolveDNSToCIDRs` (`src/controllers/utils.go`)
- Added `ctx context.Context` parameter
- Replaced unbounded `net.LookupIP` with a **3-second per-hostname timeout** via `(&net.Resolver{}).LookupIPAddr(ctx, host)`, so a slow or unreachable DNS server cannot stall the reconcile goroutine indefinitely
- Updated both call sites (`utils.go`, `languagecluster_controller.go`) to pass `ctx`

### `validateDNS` (`src/controllers/languagecluster_controller.go`)
- **Gate by `ObservedGeneration`**: skip the 10s DNS lookup if `ConditionDNSConfigured` already exists with `ObservedGeneration == cluster.Generation`
- The check now only runs when `spec.domain` changes (new generation), not on every reconcile cycle

### Tests
- `TestResolveDNSToCIDRs_ContextTimeout` — cancelled context returns empty result immediately, no stall
- `TestResolveDNSToCIDRs_WildcardAll` — `"*"` still returns `0.0.0.0/0` regardless of context state
- `TestValidateDNS_SkipsOnSameGeneration` — condition is unchanged when generation already matches