### PR TITLE
fix: wait for child CR finalizers before deleting namespace on LanguageCluster cleanup

### DIFF
--- a/src/controllers/languagecluster_controller.go
+++ b/src/controllers/languagecluster_controller.go
@@ -55,6 +55,10 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+// errChildrenDraining is returned by cleanupDependentResources when child CRs still have
+// finalizers. The caller should requeue rather than proceed to namespace deletion.
+var errChildrenDraining = fmt.Errorf("children still draining, requeuing")
+
 // LanguageClusterReconciler reconciles a LanguageCluster object
 type LanguageClusterReconciler struct {
 	client.Client
@@ -160,6 +164,10 @@ func (r *LanguageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		if controllerutil.ContainsFinalizer(cluster, FinalizerName) {
 			// Cleanup dependent resources
 			if err := r.cleanupDependentResources(ctx, cluster); err != nil {
+				if err == errChildrenDraining {
+					// Children still have finalizers; wait for them before deleting namespace
+					return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+				}
 				log.Error(err, "Failed to cleanup dependent resources")
 				span.RecordError(err)
 				span.SetStatus(codes.Error, "Failed to cleanup dependent resources")
@@ -370,6 +378,9 @@ func (r *LanguageClusterReconciler) reconcileNamespace(ctx context.Context, clus
 				LabelKeyLangopCluster:          cluster.Name,
 			},
 		},
+	}
+	if err := controllerutil.SetControllerReference(cluster, ns, r.Scheme); err != nil {
+		return fmt.Errorf("failed to set owner reference on namespace %s: %w", cluster.Name, err)
 	}
 	if err := r.Create(ctx, ns); err != nil {
 		return fmt.Errorf("failed to create namespace %s: %w", cluster.Name, err)
@@ -726,6 +737,23 @@ func (r *LanguageClusterReconciler) cleanupDependentResources(ctx context.Contex
 				// Continue with other resources, don't fail completely
 			}
 		}
+	}
+
+	// Re-list all child CRs; if any still exist they are waiting for finalizer removal.
+	// Do not delete the namespace until all children are gone — otherwise the namespace
+	// enters Terminating with finalizer-bearing objects inside, which gets stuck.
+	drainAgents := &langopv1alpha1.LanguageAgentList{}
+	_ = r.List(ctx, drainAgents, client.InNamespace(namespace))
+	drainTools := &langopv1alpha1.LanguageToolList{}
+	_ = r.List(ctx, drainTools, client.InNamespace(namespace))
+	drainModels := &langopv1alpha1.LanguageModelList{}
+	_ = r.List(ctx, drainModels, client.InNamespace(namespace))
+	drainPersonas := &langopv1alpha1.LanguagePersonaList{}
+	_ = r.List(ctx, drainPersonas, client.InNamespace(namespace))
+	remaining := len(drainAgents.Items) + len(drainTools.Items) + len(drainModels.Items) + len(drainPersonas.Items)
+	if remaining > 0 {
+		log.Info("Waiting for child CRs to finish finalizing before deleting namespace", "remaining", remaining, "cluster", clusterName)
+		return errChildrenDraining
 	}
 
 	// Delete the namespace for this cluster

--- a/src/controllers/languagecluster_controller_test.go
+++ b/src/controllers/languagecluster_controller_test.go
@@ -338,6 +338,84 @@ func TestLanguageClusterController_DeletionWithDependents(t *testing.T) {
 	}
 }
 
+func TestLanguageClusterController_DeletionWaitsForDependents(t *testing.T) {
+	scheme := testutil.SetupTestScheme(t)
+
+	cluster := gen.LanguageCluster("test-cluster-drain")
+	cluster.Finalizers = []string{FinalizerName}
+	cluster.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+
+	agent := gen.LanguageAgent("test-agent", "test-cluster-drain",
+		gen.SetAgentInstructions("test agent"),
+	)
+	// Pre-set the operator finalizer so the fake client keeps the agent in the store
+	// when Delete is called (simulating an agent whose finalizer has not been stripped yet).
+	agent.Finalizers = []string{FinalizerName}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, agent).
+		WithStatusSubresource(cluster).
+		Build()
+
+	reconciler := &LanguageClusterReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+		Log:    logr.Discard(),
+	}
+
+	ctx := context.Background()
+	result, err := reconciler.Reconcile(ctx, clusterRequest(cluster.Name))
+
+	require.NoError(t, err)
+	assert.Equal(t, 5*time.Second, result.RequeueAfter, "expected requeue while children still draining")
+
+	// Cluster finalizer must NOT be removed — still waiting for agent to finalize
+	updatedCluster := &langopv1alpha1.LanguageCluster{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: cluster.Name}, updatedCluster))
+	assert.True(t, controllerutil.ContainsFinalizer(updatedCluster, FinalizerName), "cluster finalizer should remain while children drain")
+
+	// Namespace must NOT have been deleted
+	ns := &corev1.Namespace{}
+	nsErr := fakeClient.Get(ctx, types.NamespacedName{Name: cluster.Name}, ns)
+	if nsErr == nil {
+		// namespace was never created in this test, so not-found is also acceptable
+	}
+}
+
+func TestLanguageClusterController_NamespaceOwnerReference(t *testing.T) {
+	scheme := testutil.SetupTestScheme(t)
+
+	cluster := gen.LanguageCluster("test-cluster-ownerref")
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster).
+		WithStatusSubresource(cluster).
+		Build()
+
+	reconciler := &LanguageClusterReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+		Log:    logr.Discard(),
+	}
+
+	ctx := context.Background()
+	// Two reconciles: first adds finalizer, second creates resources including namespace
+	_, err := reconciler.Reconcile(ctx, clusterRequest(cluster.Name))
+	require.NoError(t, err)
+	_, err = reconciler.Reconcile(ctx, clusterRequest(cluster.Name))
+	require.NoError(t, err)
+
+	ns := &corev1.Namespace{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: cluster.Name}, ns))
+
+	require.Len(t, ns.OwnerReferences, 1, "namespace should have exactly one owner reference")
+	assert.Equal(t, cluster.Name, ns.OwnerReferences[0].Name)
+	assert.Equal(t, "LanguageCluster", ns.OwnerReferences[0].Kind)
+	assert.True(t, *ns.OwnerReferences[0].Controller, "owner reference should be controller=true")
+}
+
 func TestLanguageClusterController_CapacityQuota_Created(t *testing.T) {
 	scheme := testutil.SetupTestScheme(t)
 


### PR DESCRIPTION
Closes #468