### PR TITLE
fix: propagate List errors in drain check instead of silently discarding them

### DIFF
--- a/src/controllers/languagecluster_controller.go
+++ b/src/controllers/languagecluster_controller.go
@@ -743,13 +743,21 @@ func (r *LanguageClusterReconciler) cleanupDependentResources(ctx context.Contex
 	// Do not delete the namespace until all children are gone — otherwise the namespace
 	// enters Terminating with finalizer-bearing objects inside, which gets stuck.
 	drainAgents := &langopv1alpha1.LanguageAgentList{}
-	_ = r.List(ctx, drainAgents, client.InNamespace(namespace))
+	if err := r.List(ctx, drainAgents, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to list agents during drain check: %w", err)
+	}
 	drainTools := &langopv1alpha1.LanguageToolList{}
-	_ = r.List(ctx, drainTools, client.InNamespace(namespace))
+	if err := r.List(ctx, drainTools, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to list tools during drain check: %w", err)
+	}
 	drainModels := &langopv1alpha1.LanguageModelList{}
-	_ = r.List(ctx, drainModels, client.InNamespace(namespace))
+	if err := r.List(ctx, drainModels, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to list models during drain check: %w", err)
+	}
 	drainPersonas := &langopv1alpha1.LanguagePersonaList{}
-	_ = r.List(ctx, drainPersonas, client.InNamespace(namespace))
+	if err := r.List(ctx, drainPersonas, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to list personas during drain check: %w", err)
+	}
 	remaining := len(drainAgents.Items) + len(drainTools.Items) + len(drainModels.Items) + len(drainPersonas.Items)
 	if remaining > 0 {
 		log.Info("Waiting for child CRs to finish finalizing before deleting namespace", "remaining", remaining, "cluster", clusterName)

--- a/src/controllers/languagecluster_controller_test.go
+++ b/src/controllers/languagecluster_controller_test.go
@@ -383,6 +383,59 @@ func TestLanguageClusterController_DeletionWaitsForDependents(t *testing.T) {
 	}
 }
 
+func TestLanguageClusterController_DeletionDrainListError(t *testing.T) {
+	scheme := testutil.SetupTestScheme(t)
+
+	cluster := gen.LanguageCluster("test-cluster-drain-err")
+	cluster.Finalizers = []string{FinalizerName}
+	cluster.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+
+	// Add an agent with a finalizer so that the drain check finds remaining children on
+	// the first reconcile. This prevents premature cleanup and lets us then inject a List
+	// error on the second reconcile to verify the error is propagated rather than discarded.
+	agent := gen.LanguageAgent("test-agent", "test-cluster-drain-err",
+		gen.SetAgentInstructions("test agent"),
+	)
+	agent.Finalizers = []string{FinalizerName}
+
+	failList := false
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, agent).
+		WithStatusSubresource(cluster).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if failList {
+					return fmt.Errorf("injected list error")
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).Build()
+
+	reconciler := &LanguageClusterReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+		Log:    logr.Discard(),
+	}
+
+	ctx := context.Background()
+	// First reconcile: drain check finds the agent and returns errChildrenDraining (requeues).
+	result, err := reconciler.Reconcile(ctx, clusterRequest(cluster.Name))
+	require.NoError(t, err)
+	assert.Equal(t, 5*time.Second, result.RequeueAfter, "expected requeue while children drain")
+
+	// Cluster finalizer must still be present.
+	updated := &langopv1alpha1.LanguageCluster{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: cluster.Name}, updated))
+	assert.True(t, controllerutil.ContainsFinalizer(updated, FinalizerName))
+
+	// Now inject a List error — it must be propagated rather than silently treated as
+	// "no children present", which would cause premature namespace deletion.
+	failList = true
+	_, err = reconciler.Reconcile(ctx, clusterRequest(cluster.Name))
+	require.Error(t, err, "List error during cleanup must be propagated, not silently discarded")
+}
+
 func TestLanguageClusterController_NamespaceOwnerReference(t *testing.T) {
 	scheme := testutil.SetupTestScheme(t)
 


### PR DESCRIPTION
Closes #496