### PR TITLE
chore: move LangopUserID and LangopGroupID constants to utils.go

### DIFF
--- a/src/controllers/languageagent_controller.go
+++ b/src/controllers/languageagent_controller.go
@@ -56,13 +56,6 @@ type LanguageAgentReconciler struct {
 	DefaultIngressClassName string
 }
 
-const (
-	// LangopUserID is the user ID for the langop user (matches Dockerfile)
-	LangopUserID = 1000
-	// LangopGroupID is the group ID for the langop group
-	LangopGroupID = 101
-)
-
 // agentConfigYAML is the structure marshaled into /etc/agent/config.yaml.
 type agentConfigYAML struct {
 	Agent        agentIdentityYAML          `yaml:"agent"`

--- a/src/controllers/utils.go
+++ b/src/controllers/utils.go
@@ -52,6 +52,11 @@ const (
 	LabelKeyLangopComponent  = "langop.io/component"
 	LabelKeyLangopConfigHash = "langop.io/config-hash"
 	LabelKeyMetadataName     = "kubernetes.io/metadata.name"
+
+	// LangopUserID is the user ID for the langop user (matches Dockerfile)
+	LangopUserID = 1000
+	// LangopGroupID is the group ID for the langop group
+	LangopGroupID = 101
 )
 
 // buildPodSecurityContext returns the operator-default pod-level security context.


### PR DESCRIPTION
Closes #517