### PR TITLE
fix: derive health-probe-bind-address from config.health.port, remove dead bindAddress field

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
         - --leader-elect-retry-period={{ .Values.config.leaderElection.retryPeriod }}
         {{- end }}
         - --metrics-bind-address={{ include "language-operator.metricsBindAddress" . }}
-        - --health-probe-bind-address={{ .Values.config.health.bindAddress }}
+        - --health-probe-bind-address=:{{ .Values.config.health.port }}
         - --zap-log-level={{ .Values.config.logging.level }}
         - --zap-encoder={{ .Values.config.logging.format }}
         {{- if .Values.config.logging.development }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -72,7 +72,6 @@ resources:
 livenessProbe:
   httpGet:
     path: /healthz
-    port: 8081
   initialDelaySeconds: 15
   periodSeconds: 20
 
@@ -80,7 +79,6 @@ livenessProbe:
 readinessProbe:
   httpGet:
     path: /readyz
-    port: 8081
   initialDelaySeconds: 5
   periodSeconds: 10
 
@@ -130,7 +128,6 @@ config:
   # Health probe configuration
   health:
     port: 8081
-    bindAddress: ":8081"
 
   # Webhook configuration
   webhook:


### PR DESCRIPTION
Closes #511