### PR TITLE
docs: fix quickstart port-forward command to use service port 18789

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -129,7 +129,7 @@ Forward the openclaw web interface:
 
 ```bash
 kubectl port-forward -n language-operator-openclaw \
-  svc/openclaw 18789:8080
+  svc/openclaw 18789:18789
 ```
 
 Open [http://localhost:18789](http://localhost:18789) in your browser.


### PR DESCRIPTION
Closes #574