### PR TITLE
docs: remove stale instructions.txt mount and two-ConfigMap references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ One controller per CRD. Each follows the same pattern:
 - Status updated last; `SetCondition` helper manages the conditions slice
 
 Key controllers:
-- `languageagent_controller.go` — main agent reconciler; creates Deployment, Service, HTTPRoute, NetworkPolicy, two ConfigMaps (instructions + config), ServiceAccount/Role/RoleBinding (all named `language-agent`, namespace-scoped), and optionally a PVC for `spec.workspace`
+- `languageagent_controller.go` — main agent reconciler; creates Deployment, Service, HTTPRoute, NetworkPolicy, one ConfigMap (`config.yaml`), ServiceAccount/Role/RoleBinding (all named `language-agent`, namespace-scoped), and optionally a PVC for `spec.workspace`
 - `languagecluster_controller.go` — reconciles the shared LiteLLM gateway (Deployment `gateway`, Service `gateway`, ConfigMap `gateway-config`) and optional Ingress/HTTPRoute at `gateway.<cluster.domain>`; watches LanguageModels to trigger re-reconcile when the model list changes
 - `languagemodel_controller.go` — reconciles status only; no longer creates any ConfigMap, Deployment, or Service — the cluster controller reads LanguageModel CRs directly when building `gateway-config`
 - `languagepersona_controller.go` — reconciles status only; the agent controller reads LanguagePersona CRs directly when building config.yaml
@@ -79,9 +79,8 @@ Webhooks live in `*_webhook.go` alongside the types. `zz_generated.deepcopy.go` 
 
 ### Agent Configuration Injection
 
-The operator mounts two files into every agent pod:
-- `/etc/agent/instructions.txt` — from `spec.instructions` (inline string)
-- `/etc/agent/config.yaml` — assembled from referenced personas, resolved tool endpoints, model configs, and agent identity
+The operator mounts one file into every agent pod:
+- `/etc/agent/config.yaml` — assembled from `spec.instructions`, referenced personas, resolved tool endpoints, model configs, and agent identity
 
 Env vars injected: `AGENT_NAME`, `AGENT_NAMESPACE`, `AGENT_UUID`, `AGENT_MODE`, `AGENT_CLUSTER_NAME`, `AGENT_CLUSTER_UUID`.
 

--- a/docs/api/languageagent.md
+++ b/docs/api/languageagent.md
@@ -50,8 +50,7 @@ See the [Complete API Reference](reference.md#languageagent) for full field docu
 
 The operator automatically mounts:
 
-- `/etc/agent/instructions.txt` - Task instructions
-- `/etc/agent/config.yaml` - Personas, models, tools
+- `/etc/agent/config.yaml` - Instructions, personas, models, tools
 
 Environment variables:
 

--- a/docs/architecture/controllers.md
+++ b/docs/architecture/controllers.md
@@ -52,9 +52,7 @@ Located in `src/controllers/utils.go`:
 - Service for agent networking
 - HTTPRoute for routing (if gateway API available)
 - NetworkPolicy for isolation
-- Two ConfigMaps:
-    - Instructions ConfigMap (`instructions.txt`)
-    - Config ConfigMap (`config.yaml` with personas, models, tools)
+- One ConfigMap (`config.yaml` with instructions, personas, models, tools)
 
 **Configuration Injection:**
 
@@ -77,8 +75,7 @@ The controller assembles configuration from:
 
 **Volume Mounts:**
 
-- `/etc/agent/instructions.txt` - from instructions ConfigMap
-- `/etc/agent/config.yaml` - from config ConfigMap
+- `/etc/agent/config.yaml` - from agent ConfigMap
 - `/workspace` - optional persistent storage (if `spec.workspace` configured)
 
 ---

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -30,12 +30,11 @@ This is the openclaw-operator pattern generalised: opinionated about K8s mechani
 
 ### 2. Configuration over Code
 
-The operator injects two files into every agent container:
+The operator injects one file into every agent container:
 
 | Path | Content |
 |------|---------|
-| `/etc/agent/instructions.txt` | Task instructions (plain text) |
-| `/etc/agent/config.yaml` | Personas, tools, models, agent identity |
+| `/etc/agent/config.yaml` | Instructions, personas, tools, models, agent identity |
 
 Instructions are what the agent does. The image is how it does it. Changing instructions requires no image rebuild.
 
@@ -125,7 +124,7 @@ spec:
       periodSeconds: 10
 ```
 
-The operator creates: Deployment, Service (on `spec.port`), HTTPRoute, NetworkPolicy, and two ConfigMaps (instructions, config).
+The operator creates: Deployment, Service (on `spec.port`), HTTPRoute, NetworkPolicy, and one ConfigMap (`config.yaml`).
 
 If `spec.deployment.initContainers` are specified, the operator prepends `MODEL_ENDPOINTS` and `LLM_MODEL` env vars into each init container so config adapters can bridge operator injection to native runtime config formats.
 
@@ -206,8 +205,7 @@ The operator creates the namespace, configures shared networking, sets up defaul
 The full contract is defined in [Agent Runtime Contract](agents.md). Summary:
 
 **Operator provides:**
-- `/etc/agent/instructions.txt` — plain text task instructions (optional)
-- `/etc/agent/config.yaml` — structured YAML with agent identity, personas, tools, models (optional)
+- `/etc/agent/config.yaml` — structured YAML with instructions, agent identity, personas, tools, models (optional)
 - Environment variables: `AGENT_NAME`, `AGENT_NAMESPACE`, `AGENT_UUID`, `AGENT_MODE`, `AGENT_CLUSTER_NAME`, `AGENT_CLUSTER_UUID`
 - `MODEL_ENDPOINTS` — URL of the shared LiteLLM gateway (`http://gateway.<namespace>.svc.cluster.local:8000`), injected into main container and all init containers
 - `LLM_MODEL` — comma-separated model names registered in the proxy (from all `models`)


### PR DESCRIPTION
Closes #570