### PR TITLE
docs: fix agent ConfigMap name from {name}-config to {name}-agent in guides

### DIFF
--- a/docs/guides/custom-agents.md
+++ b/docs/guides/custom-agents.md
@@ -188,7 +188,7 @@ kubectl get pods | grep gateway
 **Config file missing:**
 The config is mounted from a ConfigMap. Check the ConfigMap exists and the pod has it mounted:
 ```bash
-kubectl get configmap my-agent-config
+kubectl get configmap my-agent-agent
 kubectl exec deployment/my-agent -- cat /etc/agent/config.yaml
 ```
 

--- a/docs/guides/openclaw.md
+++ b/docs/guides/openclaw.md
@@ -117,7 +117,7 @@ OpenClaw listens on a **WebSocket** at port 18789 — it is not a browser HTTP U
 | Secret | `openclaw-runtime` | Auto-generated gateway token |
 | NetworkPolicy | `openclaw` | Allows inbound from other agents in this namespace |
 | PVC | `openclaw-workspace` | 10Gi persistent workspace |
-| ConfigMap | `openclaw-config` | Injected at `/etc/agent/config.yaml` |
+| ConfigMap | `openclaw-agent` | Injected at `/etc/agent/config.yaml` |
 
 ## Troubleshooting
 

--- a/docs/guides/opencode.md
+++ b/docs/guides/opencode.md
@@ -121,7 +121,7 @@ Open [http://localhost:3000](http://localhost:3000) in your browser.
 | Service | `opencode` | ClusterIP on port 3000 |
 | NetworkPolicy | `opencode` | Allows inbound from other agents in this namespace |
 | PVC | `opencode-workspace` | 10Gi persistent workspace |
-| ConfigMap | `opencode-config` | Injected at `/etc/agent/config.yaml` |
+| ConfigMap | `opencode-agent` | Injected at `/etc/agent/config.yaml` |
 
 ## Troubleshooting
 


### PR DESCRIPTION
Closes #627