### PR TITLE
fix: validate immutable workspace fields (storageClassName, accessMode) on update

### DIFF
--- a/src/api/v1alpha1/languageagent_webhook.go
+++ b/src/api/v1alpha1/languageagent_webhook.go
@@ -108,6 +108,18 @@ func (h *LanguageAgentWebhook) ValidateUpdate(ctx context.Context, newObj runtim
 				return nil, fmt.Errorf("spec.workspace.size: cannot decrease storage size (was %s, got %s)", old.Spec.Workspace.Size, a.Spec.Workspace.Size)
 			}
 		}
+		// storageClassName and accessMode are immutable PVC fields after creation.
+		oldEnabled := old.Spec.Workspace.Enabled == nil || *old.Spec.Workspace.Enabled
+		if oldEnabled {
+			if ptrStr(old.Spec.Workspace.StorageClassName) != ptrStr(a.Spec.Workspace.StorageClassName) {
+				return nil, fmt.Errorf("spec.workspace.storageClassName: field is immutable after PVC creation (was %q, got %q)",
+					ptrStr(old.Spec.Workspace.StorageClassName), ptrStr(a.Spec.Workspace.StorageClassName))
+			}
+			if old.Spec.Workspace.AccessMode != a.Spec.Workspace.AccessMode {
+				return nil, fmt.Errorf("spec.workspace.accessMode: field is immutable after PVC creation (was %q, got %q)",
+					old.Spec.Workspace.AccessMode, a.Spec.Workspace.AccessMode)
+			}
+		}
 	}
 	warns, err := h.validateRuntime(ctx, a)
 	if err != nil {
@@ -115,6 +127,14 @@ func (h *LanguageAgentWebhook) ValidateUpdate(ctx context.Context, newObj runtim
 	}
 	warns = append(warns, securityWarnings(a)...)
 	return warns, a.validateSpec()
+}
+
+// ptrStr dereferences a string pointer, returning "" for nil.
+func ptrStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 // securityWarnings returns advisory (non-blocking) warnings for dangerous agent configurations.

--- a/src/api/v1alpha1/languageagent_webhook_test.go
+++ b/src/api/v1alpha1/languageagent_webhook_test.go
@@ -601,6 +601,8 @@ func TestLanguageAgentSecurityWarnings(t *testing.T) {
 	}
 }
 
+func strPtr(s string) *string { return &s }
+
 func TestLanguageAgentValidateUpdate(t *testing.T) {
 	const ns = "default"
 	ctx := context.Background()
@@ -657,6 +659,162 @@ func TestLanguageAgentValidateUpdate(t *testing.T) {
 			newAgent: &LanguageAgent{
 				ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: ns},
 				Spec:       LanguageAgentSpec{Image: "test:latest", Instructions: "test"},
+			},
+			expectErr: false,
+		},
+		// storageClassName immutability
+		{
+			name: "storageClassName changed - rejected",
+			oldAgent: &LanguageAgent{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: ns},
+				Spec: LanguageAgentSpec{
+					Image:        "test:latest",
+					Instructions: "test",
+					Workspace:    &WorkspaceSpec{Size: "10Gi", StorageClassName: strPtr("fast-ssd")},
+				},
+			},
+			newAgent: &LanguageAgent{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: ns},
+				Spec: LanguageAgentSpec{
+					Image:        "test:latest",
+					Instructions: "test",
+					Workspace:    &WorkspaceSpec{Size: "10Gi", StorageClassName: strPtr("standard")},
+				},
+			},
+			expectErr: true,
+			errMsg:    "storageClassName",
+		},
+		{
+			name: "storageClassName nil to set - rejected",
+			oldAgent: &LanguageAgent{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: ns},
+				Spec: LanguageAgentSpec{
+					Image:        "test:latest",
+					Instructions: "test",
+					Workspace:    &WorkspaceSpec{Size: "10Gi"},
+				},
+			},
+			newAgent: &LanguageAgent{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: ns},
+				Spec: LanguageAgentSpec{
+					Image:        "test:latest",
+					Instructions: "test",
+					Workspace:    &WorkspaceSpec{Size: "10Gi", StorageClassName: strPtr("fast-ssd")},
+				},
+			},
+			expectErr: true,
+			errMsg:    "storageClassName",
+		},
+		{
+			name: "storageClassName set to nil - rejected",
+			oldAgent: &LanguageAgent{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: ns},
+				Spec: LanguageAgentSpec{
+					Image:        "test:latest",
+					Instructions: "test",
+					Workspace:    &WorkspaceSpec{Size: "10Gi", StorageClassName: strPtr("fast-ssd")},
+				},
+			},
+			newAgent: &LanguageAgent{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: ns},
+				Spec: LanguageAgentSpec{
+					Image:        "test:latest",
+					Instructions: "test",
+					Workspace:    &WorkspaceSpec{Size: "10Gi"},
+				},
+			},
+			expectErr: true,
+			errMsg:    "storageClassName",
+		},
+		{
+			name: "storageClassName unchanged - allowed",
+			oldAgent: &LanguageAgent{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: ns},
+				Spec: LanguageAgentSpec{
+					Image:        "test:latest",
+					Instructions: "test",
+					Workspace:    &WorkspaceSpec{Size: "10Gi", StorageClassName: strPtr("fast-ssd")},
+				},
+			},
+			newAgent: &LanguageAgent{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: ns},
+				Spec: LanguageAgentSpec{
+					Image:        "test:latest",
+					Instructions: "test",
+					Workspace:    &WorkspaceSpec{Size: "10Gi", StorageClassName: strPtr("fast-ssd")},
+				},
+			},
+			expectErr: false,
+		},
+		// accessMode immutability
+		{
+			name: "accessMode changed - rejected",
+			oldAgent: &LanguageAgent{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: ns},
+				Spec: LanguageAgentSpec{
+					Image:        "test:latest",
+					Instructions: "test",
+					Workspace:    &WorkspaceSpec{Size: "10Gi", AccessMode: "ReadWriteOnce"},
+				},
+			},
+			newAgent: &LanguageAgent{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: ns},
+				Spec: LanguageAgentSpec{
+					Image:        "test:latest",
+					Instructions: "test",
+					Workspace:    &WorkspaceSpec{Size: "10Gi", AccessMode: "ReadWriteMany"},
+				},
+			},
+			expectErr: true,
+			errMsg:    "accessMode",
+		},
+		{
+			name: "accessMode unchanged - allowed",
+			oldAgent: &LanguageAgent{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: ns},
+				Spec: LanguageAgentSpec{
+					Image:        "test:latest",
+					Instructions: "test",
+					Workspace:    &WorkspaceSpec{Size: "10Gi", AccessMode: "ReadWriteOnce"},
+				},
+			},
+			newAgent: &LanguageAgent{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: ns},
+				Spec: LanguageAgentSpec{
+					Image:        "test:latest",
+					Instructions: "test",
+					Workspace:    &WorkspaceSpec{Size: "10Gi", AccessMode: "ReadWriteOnce"},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "old workspace disabled - immutable fields not enforced",
+			oldAgent: &LanguageAgent{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: ns},
+				Spec: LanguageAgentSpec{
+					Image:        "test:latest",
+					Instructions: "test",
+					Workspace: &WorkspaceSpec{
+						Enabled:          boolPtr(false),
+						Size:             "10Gi",
+						StorageClassName: strPtr("fast-ssd"),
+						AccessMode:       "ReadWriteOnce",
+					},
+				},
+			},
+			newAgent: &LanguageAgent{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: ns},
+				Spec: LanguageAgentSpec{
+					Image:        "test:latest",
+					Instructions: "test",
+					Workspace: &WorkspaceSpec{
+						Enabled:          boolPtr(true),
+						Size:             "10Gi",
+						StorageClassName: strPtr("standard"),
+						AccessMode:       "ReadWriteMany",
+					},
+				},
 			},
 			expectErr: false,
 		},


### PR DESCRIPTION
Closes #709