### PR TITLE
feat: per-agent ServiceAccount with annotations and custom RBAC rules

### DIFF
--- a/chart/crds/langop.io_languageagentruntimes.yaml
+++ b/chart/crds/langop.io_languageagentruntimes.yaml
@@ -3334,6 +3334,56 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  roleRules:
+                    description: |-
+                      RoleRules are additional RBAC policy rules appended to the operator-managed Role.
+                      Use this to grant the agent extra in-cluster permissions beyond the defaults
+                      (configmaps get/list, pods get/list/watch).
+                      Ignored when ServiceAccountName is set.
+                    items:
+                      description: |-
+                        PolicyRule holds information that describes a policy rule, but does not contain information
+                        about who the rule applies to or which namespace the rule applies to.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+                            the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
+                          items:
+                            type: string
+                          type: array
+                        nonResourceURLs:
+                          description: |-
+                            NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+                            Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
+                            Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+                          items:
+                            type: string
+                          type: array
+                        resourceNames:
+                          description: ResourceNames is an optional white list of
+                            names that the rule applies to.  An empty set means that
+                            everything is allowed.
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: Resources is a list of resources this rule
+                            applies to. '*' represents all resources.
+                          items:
+                            type: string
+                          type: array
+                        verbs:
+                          description: Verbs is a list of Verbs that apply to ALL
+                            the ResourceKinds contained in this rule. '*' represents
+                            all verbs.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - verbs
+                      type: object
+                    type: array
                   securityContext:
                     description: SecurityContext holds pod-level security attributes.
                     properties:
@@ -3504,6 +3554,14 @@ spec:
                               PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: string
                         type: object
+                    type: object
+                  serviceAccountAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      ServiceAccountAnnotations are annotations to add to the operator-managed ServiceAccount.
+                      Use this to attach cloud workload identity bindings, e.g. AWS IRSA, GCP WI, AKS WI.
+                      Ignored when ServiceAccountName is set.
                     type: object
                   serviceAccountName:
                     description: ServiceAccountName is the name of the ServiceAccount

--- a/chart/crds/langop.io_languageagents.yaml
+++ b/chart/crds/langop.io_languageagents.yaml
@@ -3337,6 +3337,56 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  roleRules:
+                    description: |-
+                      RoleRules are additional RBAC policy rules appended to the operator-managed Role.
+                      Use this to grant the agent extra in-cluster permissions beyond the defaults
+                      (configmaps get/list, pods get/list/watch).
+                      Ignored when ServiceAccountName is set.
+                    items:
+                      description: |-
+                        PolicyRule holds information that describes a policy rule, but does not contain information
+                        about who the rule applies to or which namespace the rule applies to.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+                            the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
+                          items:
+                            type: string
+                          type: array
+                        nonResourceURLs:
+                          description: |-
+                            NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+                            Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
+                            Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+                          items:
+                            type: string
+                          type: array
+                        resourceNames:
+                          description: ResourceNames is an optional white list of
+                            names that the rule applies to.  An empty set means that
+                            everything is allowed.
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: Resources is a list of resources this rule
+                            applies to. '*' represents all resources.
+                          items:
+                            type: string
+                          type: array
+                        verbs:
+                          description: Verbs is a list of Verbs that apply to ALL
+                            the ResourceKinds contained in this rule. '*' represents
+                            all verbs.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - verbs
+                      type: object
+                    type: array
                   securityContext:
                     description: SecurityContext holds pod-level security attributes.
                     properties:
@@ -3507,6 +3557,14 @@ spec:
                               PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: string
                         type: object
+                    type: object
+                  serviceAccountAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      ServiceAccountAnnotations are annotations to add to the operator-managed ServiceAccount.
+                      Use this to attach cloud workload identity bindings, e.g. AWS IRSA, GCP WI, AKS WI.
+                      Ignored when ServiceAccountName is set.
                     type: object
                   serviceAccountName:
                     description: ServiceAccountName is the name of the ServiceAccount

--- a/chart/crds/langop.io_languageclusters.yaml
+++ b/chart/crds/langop.io_languageclusters.yaml
@@ -3415,6 +3415,56 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      roleRules:
+                        description: |-
+                          RoleRules are additional RBAC policy rules appended to the operator-managed Role.
+                          Use this to grant the agent extra in-cluster permissions beyond the defaults
+                          (configmaps get/list, pods get/list/watch).
+                          Ignored when ServiceAccountName is set.
+                        items:
+                          description: |-
+                            PolicyRule holds information that describes a policy rule, but does not contain information
+                            about who the rule applies to or which namespace the rule applies to.
+                          properties:
+                            apiGroups:
+                              description: |-
+                                APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+                                the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
+                              items:
+                                type: string
+                              type: array
+                            nonResourceURLs:
+                              description: |-
+                                NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+                                Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
+                                Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+                              items:
+                                type: string
+                              type: array
+                            resourceNames:
+                              description: ResourceNames is an optional white list
+                                of names that the rule applies to.  An empty set means
+                                that everything is allowed.
+                              items:
+                                type: string
+                              type: array
+                            resources:
+                              description: Resources is a list of resources this rule
+                                applies to. '*' represents all resources.
+                              items:
+                                type: string
+                              type: array
+                            verbs:
+                              description: Verbs is a list of Verbs that apply to
+                                ALL the ResourceKinds contained in this rule. '*'
+                                represents all verbs.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - verbs
+                          type: object
+                        type: array
                       securityContext:
                         description: SecurityContext holds pod-level security attributes.
                         properties:
@@ -3586,6 +3636,14 @@ spec:
                                   PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: string
                             type: object
+                        type: object
+                      serviceAccountAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          ServiceAccountAnnotations are annotations to add to the operator-managed ServiceAccount.
+                          Use this to attach cloud workload identity bindings, e.g. AWS IRSA, GCP WI, AKS WI.
+                          Ignored when ServiceAccountName is set.
                         type: object
                       serviceAccountName:
                         description: ServiceAccountName is the name of the ServiceAccount

--- a/chart/crds/langop.io_languagetools.yaml
+++ b/chart/crds/langop.io_languagetools.yaml
@@ -3337,6 +3337,56 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  roleRules:
+                    description: |-
+                      RoleRules are additional RBAC policy rules appended to the operator-managed Role.
+                      Use this to grant the agent extra in-cluster permissions beyond the defaults
+                      (configmaps get/list, pods get/list/watch).
+                      Ignored when ServiceAccountName is set.
+                    items:
+                      description: |-
+                        PolicyRule holds information that describes a policy rule, but does not contain information
+                        about who the rule applies to or which namespace the rule applies to.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+                            the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
+                          items:
+                            type: string
+                          type: array
+                        nonResourceURLs:
+                          description: |-
+                            NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+                            Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
+                            Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+                          items:
+                            type: string
+                          type: array
+                        resourceNames:
+                          description: ResourceNames is an optional white list of
+                            names that the rule applies to.  An empty set means that
+                            everything is allowed.
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: Resources is a list of resources this rule
+                            applies to. '*' represents all resources.
+                          items:
+                            type: string
+                          type: array
+                        verbs:
+                          description: Verbs is a list of Verbs that apply to ALL
+                            the ResourceKinds contained in this rule. '*' represents
+                            all verbs.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - verbs
+                      type: object
+                    type: array
                   securityContext:
                     description: SecurityContext holds pod-level security attributes.
                     properties:
@@ -3507,6 +3557,14 @@ spec:
                               PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: string
                         type: object
+                    type: object
+                  serviceAccountAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      ServiceAccountAnnotations are annotations to add to the operator-managed ServiceAccount.
+                      Use this to attach cloud workload identity bindings, e.g. AWS IRSA, GCP WI, AKS WI.
+                      Ignored when ServiceAccountName is set.
                     type: object
                   serviceAccountName:
                     description: ServiceAccountName is the name of the ServiceAccount

--- a/src/api/v1alpha1/languagecluster_types.go
+++ b/src/api/v1alpha1/languagecluster_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -146,6 +147,19 @@ type DeploymentSpec struct {
 	// ServiceAccountName is the name of the ServiceAccount to use.
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+
+	// ServiceAccountAnnotations are annotations to add to the operator-managed ServiceAccount.
+	// Use this to attach cloud workload identity bindings, e.g. AWS IRSA, GCP WI, AKS WI.
+	// Ignored when ServiceAccountName is set.
+	// +optional
+	ServiceAccountAnnotations map[string]string `json:"serviceAccountAnnotations,omitempty"`
+
+	// RoleRules are additional RBAC policy rules appended to the operator-managed Role.
+	// Use this to grant the agent extra in-cluster permissions beyond the defaults
+	// (configmaps get/list, pods get/list/watch).
+	// Ignored when ServiceAccountName is set.
+	// +optional
+	RoleRules []rbacv1.PolicyRule `json:"roleRules,omitempty"`
 
 	// SecurityContext holds pod-level security attributes.
 	// +optional

--- a/src/api/v1alpha1/zz_generated.deepcopy.go
+++ b/src/api/v1alpha1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1alpha1
 import (
 	"k8s.io/api/autoscaling/v2"
 	"k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -210,6 +211,20 @@ func (in *DeploymentSpec) DeepCopyInto(out *DeploymentSpec) {
 	if in.TopologySpreadConstraints != nil {
 		in, out := &in.TopologySpreadConstraints, &out.TopologySpreadConstraints
 		*out = make([]v1.TopologySpreadConstraint, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.ServiceAccountAnnotations != nil {
+		in, out := &in.ServiceAccountAnnotations, &out.ServiceAccountAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.RoleRules != nil {
+		in, out := &in.RoleRules, &out.RoleRules
+		*out = make([]rbacv1.PolicyRule, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/src/config/crd/bases/langop.io_languageagentruntimes.yaml
+++ b/src/config/crd/bases/langop.io_languageagentruntimes.yaml
@@ -3334,6 +3334,56 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  roleRules:
+                    description: |-
+                      RoleRules are additional RBAC policy rules appended to the operator-managed Role.
+                      Use this to grant the agent extra in-cluster permissions beyond the defaults
+                      (configmaps get/list, pods get/list/watch).
+                      Ignored when ServiceAccountName is set.
+                    items:
+                      description: |-
+                        PolicyRule holds information that describes a policy rule, but does not contain information
+                        about who the rule applies to or which namespace the rule applies to.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+                            the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
+                          items:
+                            type: string
+                          type: array
+                        nonResourceURLs:
+                          description: |-
+                            NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+                            Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
+                            Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+                          items:
+                            type: string
+                          type: array
+                        resourceNames:
+                          description: ResourceNames is an optional white list of
+                            names that the rule applies to.  An empty set means that
+                            everything is allowed.
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: Resources is a list of resources this rule
+                            applies to. '*' represents all resources.
+                          items:
+                            type: string
+                          type: array
+                        verbs:
+                          description: Verbs is a list of Verbs that apply to ALL
+                            the ResourceKinds contained in this rule. '*' represents
+                            all verbs.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - verbs
+                      type: object
+                    type: array
                   securityContext:
                     description: SecurityContext holds pod-level security attributes.
                     properties:
@@ -3504,6 +3554,14 @@ spec:
                               PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: string
                         type: object
+                    type: object
+                  serviceAccountAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      ServiceAccountAnnotations are annotations to add to the operator-managed ServiceAccount.
+                      Use this to attach cloud workload identity bindings, e.g. AWS IRSA, GCP WI, AKS WI.
+                      Ignored when ServiceAccountName is set.
                     type: object
                   serviceAccountName:
                     description: ServiceAccountName is the name of the ServiceAccount

--- a/src/config/crd/bases/langop.io_languageagents.yaml
+++ b/src/config/crd/bases/langop.io_languageagents.yaml
@@ -3337,6 +3337,56 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  roleRules:
+                    description: |-
+                      RoleRules are additional RBAC policy rules appended to the operator-managed Role.
+                      Use this to grant the agent extra in-cluster permissions beyond the defaults
+                      (configmaps get/list, pods get/list/watch).
+                      Ignored when ServiceAccountName is set.
+                    items:
+                      description: |-
+                        PolicyRule holds information that describes a policy rule, but does not contain information
+                        about who the rule applies to or which namespace the rule applies to.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+                            the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
+                          items:
+                            type: string
+                          type: array
+                        nonResourceURLs:
+                          description: |-
+                            NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+                            Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
+                            Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+                          items:
+                            type: string
+                          type: array
+                        resourceNames:
+                          description: ResourceNames is an optional white list of
+                            names that the rule applies to.  An empty set means that
+                            everything is allowed.
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: Resources is a list of resources this rule
+                            applies to. '*' represents all resources.
+                          items:
+                            type: string
+                          type: array
+                        verbs:
+                          description: Verbs is a list of Verbs that apply to ALL
+                            the ResourceKinds contained in this rule. '*' represents
+                            all verbs.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - verbs
+                      type: object
+                    type: array
                   securityContext:
                     description: SecurityContext holds pod-level security attributes.
                     properties:
@@ -3507,6 +3557,14 @@ spec:
                               PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: string
                         type: object
+                    type: object
+                  serviceAccountAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      ServiceAccountAnnotations are annotations to add to the operator-managed ServiceAccount.
+                      Use this to attach cloud workload identity bindings, e.g. AWS IRSA, GCP WI, AKS WI.
+                      Ignored when ServiceAccountName is set.
                     type: object
                   serviceAccountName:
                     description: ServiceAccountName is the name of the ServiceAccount

--- a/src/config/crd/bases/langop.io_languageclusters.yaml
+++ b/src/config/crd/bases/langop.io_languageclusters.yaml
@@ -3415,6 +3415,56 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      roleRules:
+                        description: |-
+                          RoleRules are additional RBAC policy rules appended to the operator-managed Role.
+                          Use this to grant the agent extra in-cluster permissions beyond the defaults
+                          (configmaps get/list, pods get/list/watch).
+                          Ignored when ServiceAccountName is set.
+                        items:
+                          description: |-
+                            PolicyRule holds information that describes a policy rule, but does not contain information
+                            about who the rule applies to or which namespace the rule applies to.
+                          properties:
+                            apiGroups:
+                              description: |-
+                                APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+                                the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
+                              items:
+                                type: string
+                              type: array
+                            nonResourceURLs:
+                              description: |-
+                                NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+                                Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
+                                Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+                              items:
+                                type: string
+                              type: array
+                            resourceNames:
+                              description: ResourceNames is an optional white list
+                                of names that the rule applies to.  An empty set means
+                                that everything is allowed.
+                              items:
+                                type: string
+                              type: array
+                            resources:
+                              description: Resources is a list of resources this rule
+                                applies to. '*' represents all resources.
+                              items:
+                                type: string
+                              type: array
+                            verbs:
+                              description: Verbs is a list of Verbs that apply to
+                                ALL the ResourceKinds contained in this rule. '*'
+                                represents all verbs.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - verbs
+                          type: object
+                        type: array
                       securityContext:
                         description: SecurityContext holds pod-level security attributes.
                         properties:
@@ -3586,6 +3636,14 @@ spec:
                                   PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: string
                             type: object
+                        type: object
+                      serviceAccountAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          ServiceAccountAnnotations are annotations to add to the operator-managed ServiceAccount.
+                          Use this to attach cloud workload identity bindings, e.g. AWS IRSA, GCP WI, AKS WI.
+                          Ignored when ServiceAccountName is set.
                         type: object
                       serviceAccountName:
                         description: ServiceAccountName is the name of the ServiceAccount

--- a/src/config/crd/bases/langop.io_languagetools.yaml
+++ b/src/config/crd/bases/langop.io_languagetools.yaml
@@ -3337,6 +3337,56 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  roleRules:
+                    description: |-
+                      RoleRules are additional RBAC policy rules appended to the operator-managed Role.
+                      Use this to grant the agent extra in-cluster permissions beyond the defaults
+                      (configmaps get/list, pods get/list/watch).
+                      Ignored when ServiceAccountName is set.
+                    items:
+                      description: |-
+                        PolicyRule holds information that describes a policy rule, but does not contain information
+                        about who the rule applies to or which namespace the rule applies to.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+                            the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
+                          items:
+                            type: string
+                          type: array
+                        nonResourceURLs:
+                          description: |-
+                            NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+                            Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
+                            Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+                          items:
+                            type: string
+                          type: array
+                        resourceNames:
+                          description: ResourceNames is an optional white list of
+                            names that the rule applies to.  An empty set means that
+                            everything is allowed.
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: Resources is a list of resources this rule
+                            applies to. '*' represents all resources.
+                          items:
+                            type: string
+                          type: array
+                        verbs:
+                          description: Verbs is a list of Verbs that apply to ALL
+                            the ResourceKinds contained in this rule. '*' represents
+                            all verbs.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - verbs
+                      type: object
+                    type: array
                   securityContext:
                     description: SecurityContext holds pod-level security attributes.
                     properties:
@@ -3507,6 +3557,14 @@ spec:
                               PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: string
                         type: object
+                    type: object
+                  serviceAccountAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      ServiceAccountAnnotations are annotations to add to the operator-managed ServiceAccount.
+                      Use this to attach cloud workload identity bindings, e.g. AWS IRSA, GCP WI, AKS WI.
+                      Ignored when ServiceAccountName is set.
                     type: object
                   serviceAccountName:
                     description: ServiceAccountName is the name of the ServiceAccount

--- a/src/controllers/languageagent_controller.go
+++ b/src/controllers/languageagent_controller.go
@@ -173,9 +173,9 @@ func (r *LanguageAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if !agent.DeletionTimestamp.IsZero() {
 		span.AddEvent("Deleting agent")
 		if controllerutil.ContainsFinalizer(agent, FinalizerName) {
-			// Shared RBAC resources (ServiceAccount, Role, RoleBinding named "language-agent")
-			// have no owner reference and are not GC'd automatically; clean them up explicitly
-			// when the last agent in the namespace is deleted.
+			// Per-agent RBAC resources (ServiceAccount, Role, RoleBinding named
+			// "language-agent-<agent>") have no owner reference and are not GC'd
+			// automatically; clean them up explicitly on deletion.
 			if err := r.cleanupResources(ctx, agent); err != nil {
 				span.RecordError(err)
 				span.SetStatus(codes.Error, "Failed to clean up agent resources")
@@ -1451,8 +1451,9 @@ func (r *LanguageAgentReconciler) cleanupResources(ctx context.Context, agent *l
 	// Exception: when spec.workspace.retain is true, strip the PVC's ownerReference
 	// before the finalizer is removed so GC does not collect it.
 	//
-	// The only manual cleanup required is shared RBAC resources, which are not owned by
-	// any single agent and must be removed when the last agent in the namespace is deleted.
+	// Per-agent RBAC resources (ServiceAccount, Role, RoleBinding) are not owned by the
+	// agent (ServiceAccounts cannot be owner-referenced from Pods across namespaces) so
+	// they must be deleted explicitly here.
 	if agent.Spec.Workspace != nil &&
 		(agent.Spec.Workspace.Enabled == nil || *agent.Spec.Workspace.Enabled) &&
 		agent.Spec.Workspace.Retain {
@@ -1460,7 +1461,7 @@ func (r *LanguageAgentReconciler) cleanupResources(ctx context.Context, agent *l
 			return err
 		}
 	}
-	return r.cleanupSharedRBAC(ctx, agent)
+	return r.cleanupPerAgentRBAC(ctx, agent)
 }
 
 // orphanWorkspacePVC removes the ownerReference from the workspace PVC so that
@@ -1483,35 +1484,28 @@ func (r *LanguageAgentReconciler) orphanWorkspacePVC(ctx context.Context, agent 
 	return nil
 }
 
-// cleanupSharedRBAC deletes the shared ServiceAccount, Role, and RoleBinding for agent pods
-// in the given namespace, but only when no other LanguageAgents remain in that namespace.
-func (r *LanguageAgentReconciler) cleanupSharedRBAC(ctx context.Context, agent *langopv1alpha1.LanguageAgent) error {
+// cleanupPerAgentRBAC deletes the per-agent ServiceAccount, Role, and RoleBinding.
+// These are not covered by owner-reference GC because ServiceAccounts cannot be
+// owner-referenced from Pods across namespaces, so they must be deleted explicitly.
+// Skipped when a custom ServiceAccountName is set (user manages their own SA).
+func (r *LanguageAgentReconciler) cleanupPerAgentRBAC(ctx context.Context, agent *langopv1alpha1.LanguageAgent) error {
+	if agent.Spec.Deployment.ServiceAccountName != "" {
+		return nil
+	}
 	log := log.FromContext(ctx)
 	ns := agent.Namespace
+	saName := GenerateServiceAccountName(agent.Name)
 
-	// Check whether any other agents remain in this namespace
-	agentList := &langopv1alpha1.LanguageAgentList{}
-	if err := r.List(ctx, agentList, client.InNamespace(ns)); err != nil {
-		return fmt.Errorf("failed to list LanguageAgents: %w", err)
-	}
-	for _, a := range agentList.Items {
-		if a.Name != agent.Name && a.DeletionTimestamp.IsZero() {
-			// Another live agent still exists; leave shared resources intact
-			return nil
-		}
-	}
-
-	// Last agent in namespace — delete shared RBAC resources
 	toDelete := []client.Object{
-		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "language-agent", Namespace: ns}},
-		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "language-agent", Namespace: ns}},
-		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "language-agent", Namespace: ns}},
+		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: ns}},
+		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: ns}},
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: ns}},
 	}
 	for _, obj := range toDelete {
 		if err := r.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete %T %s: %w", obj, "language-agent", err)
+			return fmt.Errorf("failed to delete %T %s: %w", obj, saName, err)
 		}
-		log.Info("Deleted shared RBAC resource", "kind", fmt.Sprintf("%T", obj), "namespace", ns)
+		log.Info("Deleted per-agent RBAC resource", "kind", fmt.Sprintf("%T", obj), "name", saName, "namespace", ns)
 	}
 	return nil
 }
@@ -1998,23 +1992,31 @@ func (r *LanguageAgentReconciler) reconcileAgentServiceAccount(ctx context.Conte
 
 	// ServiceAccount always lives in the agent's own namespace
 	targetNamespace := agent.Namespace
+	saName := GenerateServiceAccountName(agent.Name)
 
 	// Create ServiceAccount
 	serviceAccount := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "language-agent",
+			Name:      saName,
 			Namespace: targetNamespace,
 		},
 	}
 
 	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, serviceAccount, func() error {
-		// Set labels
 		if serviceAccount.Labels == nil {
 			serviceAccount.Labels = make(map[string]string)
 		}
-		serviceAccount.Labels[LabelKeyK8sName] = "language-agent"
+		serviceAccount.Labels[LabelKeyK8sName] = saName
 		serviceAccount.Labels[LabelKeyK8sComponent] = "serviceaccount"
 		serviceAccount.Labels[LabelKeyK8sManagedBy] = "language-operator"
+
+		// Merge user-supplied annotations (e.g. IRSA, GCP WI, AKS WI)
+		if len(agent.Spec.Deployment.ServiceAccountAnnotations) > 0 {
+			if serviceAccount.Annotations == nil {
+				serviceAccount.Annotations = make(map[string]string)
+			}
+			maps.Copy(serviceAccount.Annotations, agent.Spec.Deployment.ServiceAccountAnnotations)
+		}
 
 		return nil
 	})
@@ -2026,7 +2028,7 @@ func (r *LanguageAgentReconciler) reconcileAgentServiceAccount(ctx context.Conte
 	// Create namespace-scoped Role with minimal permissions for agent pods
 	role := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "language-agent",
+			Name:      saName,
 			Namespace: targetNamespace,
 		},
 	}
@@ -2035,7 +2037,7 @@ func (r *LanguageAgentReconciler) reconcileAgentServiceAccount(ctx context.Conte
 		if role.Labels == nil {
 			role.Labels = make(map[string]string)
 		}
-		role.Labels[LabelKeyK8sName] = "language-agent"
+		role.Labels[LabelKeyK8sName] = saName
 		role.Labels[LabelKeyK8sComponent] = "role"
 		role.Labels[LabelKeyK8sManagedBy] = "language-operator"
 		role.Rules = []rbacv1.PolicyRule{
@@ -2050,6 +2052,7 @@ func (r *LanguageAgentReconciler) reconcileAgentServiceAccount(ctx context.Conte
 				Verbs:     []string{"get", "list", "watch"},
 			},
 		}
+		role.Rules = append(role.Rules, agent.Spec.Deployment.RoleRules...)
 		return nil
 	})
 
@@ -2060,7 +2063,7 @@ func (r *LanguageAgentReconciler) reconcileAgentServiceAccount(ctx context.Conte
 	// Create namespace-scoped RoleBinding binding the ServiceAccount to the Role
 	roleBinding := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "language-agent",
+			Name:      saName,
 			Namespace: targetNamespace,
 		},
 	}
@@ -2069,18 +2072,18 @@ func (r *LanguageAgentReconciler) reconcileAgentServiceAccount(ctx context.Conte
 		if roleBinding.Labels == nil {
 			roleBinding.Labels = make(map[string]string)
 		}
-		roleBinding.Labels[LabelKeyK8sName] = "language-agent"
+		roleBinding.Labels[LabelKeyK8sName] = saName
 		roleBinding.Labels[LabelKeyK8sComponent] = "rolebinding"
 		roleBinding.Labels[LabelKeyK8sManagedBy] = "language-operator"
 		roleBinding.RoleRef = rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "Role",
-			Name:     "language-agent",
+			Name:     saName,
 		}
 		roleBinding.Subjects = []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Name:      "language-agent",
+				Name:      saName,
 				Namespace: targetNamespace,
 			},
 		}
@@ -2092,7 +2095,7 @@ func (r *LanguageAgentReconciler) reconcileAgentServiceAccount(ctx context.Conte
 	}
 
 	log.Info("Reconciled agent ServiceAccount and permissions",
-		"serviceAccount", "language-agent",
+		"serviceAccount", saName,
 		"namespace", targetNamespace,
 		"role", role.Name,
 		"roleBinding", roleBinding.Name)
@@ -2107,8 +2110,8 @@ func (r *LanguageAgentReconciler) getServiceAccountName(agent *langopv1alpha1.La
 		return agent.Spec.Deployment.ServiceAccountName
 	}
 
-	// Default to a language-agent ServiceAccount that will be created in the agent's namespace
-	return "language-agent"
+	// Default to an operator-managed per-agent ServiceAccount
+	return GenerateServiceAccountName(agent.Name)
 }
 
 // generateCredential returns a cryptographically random 32-byte hex string.
@@ -2309,12 +2312,13 @@ func (r *LanguageAgentReconciler) buildAgentManagedResources(
 		})
 	}
 
-	// Shared RBAC resources are created when no custom ServiceAccount is specified.
+	// Per-agent RBAC resources are created when no custom ServiceAccount is specified.
 	if agent.Spec.Deployment.ServiceAccountName == "" {
+		saName := GenerateServiceAccountName(agent.Name)
 		resources = append(resources,
-			langopv1alpha1.ManagedResource{Kind: "ServiceAccount", Name: "language-agent", Namespace: ns},
-			langopv1alpha1.ManagedResource{Group: "rbac.authorization.k8s.io", Kind: "Role", Name: "language-agent", Namespace: ns},
-			langopv1alpha1.ManagedResource{Group: "rbac.authorization.k8s.io", Kind: "RoleBinding", Name: "language-agent", Namespace: ns},
+			langopv1alpha1.ManagedResource{Kind: "ServiceAccount", Name: saName, Namespace: ns},
+			langopv1alpha1.ManagedResource{Group: "rbac.authorization.k8s.io", Kind: "Role", Name: saName, Namespace: ns},
+			langopv1alpha1.ManagedResource{Group: "rbac.authorization.k8s.io", Kind: "RoleBinding", Name: saName, Namespace: ns},
 		)
 	}
 

--- a/src/controllers/languageagent_controller_test.go
+++ b/src/controllers/languageagent_controller_test.go
@@ -658,10 +658,11 @@ func TestLanguageAgentController_DeletionRemovesFinalizer(t *testing.T) {
 		},
 	}
 
-	// Pre-create shared RBAC resources that should be deleted when the last agent goes away.
-	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "language-agent", Namespace: "default"}}
-	role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "language-agent", Namespace: "default"}}
-	rb := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "language-agent", Namespace: "default"}}
+	// Pre-create per-agent RBAC resources that should be deleted on agent deletion.
+	saName := GenerateServiceAccountName(agent.Name)
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: "default"}}
+	role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: "default"}}
+	rb := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: "default"}}
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -708,21 +709,21 @@ func TestLanguageAgentController_DeletionRemovesFinalizer(t *testing.T) {
 		}
 	}
 
-	// Shared RBAC resources must be deleted when the last agent is gone.
-	if err := fakeClient.Get(ctx, types.NamespacedName{Name: "language-agent", Namespace: "default"}, &corev1.ServiceAccount{}); !errors.IsNotFound(err) {
-		t.Errorf("Expected ServiceAccount/language-agent to be deleted, got: %v", err)
+	// Per-agent RBAC resources must be deleted on agent deletion.
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: saName, Namespace: "default"}, &corev1.ServiceAccount{}); !errors.IsNotFound(err) {
+		t.Errorf("Expected ServiceAccount/%s to be deleted, got: %v", saName, err)
 	}
-	if err := fakeClient.Get(ctx, types.NamespacedName{Name: "language-agent", Namespace: "default"}, &rbacv1.Role{}); !errors.IsNotFound(err) {
-		t.Errorf("Expected Role/language-agent to be deleted, got: %v", err)
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: saName, Namespace: "default"}, &rbacv1.Role{}); !errors.IsNotFound(err) {
+		t.Errorf("Expected Role/%s to be deleted, got: %v", saName, err)
 	}
-	if err := fakeClient.Get(ctx, types.NamespacedName{Name: "language-agent", Namespace: "default"}, &rbacv1.RoleBinding{}); !errors.IsNotFound(err) {
-		t.Errorf("Expected RoleBinding/language-agent to be deleted, got: %v", err)
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: saName, Namespace: "default"}, &rbacv1.RoleBinding{}); !errors.IsNotFound(err) {
+		t.Errorf("Expected RoleBinding/%s to be deleted, got: %v", saName, err)
 	}
 }
 
-// TestLanguageAgentController_DeletionKeepsRBACWhenOtherAgentsExist verifies that shared
-// RBAC resources are NOT deleted when another LanguageAgent still exists in the namespace.
-func TestLanguageAgentController_DeletionKeepsRBACWhenOtherAgentsExist(t *testing.T) {
+// TestLanguageAgentController_DeletionCleansPerAgentRBACLeavesOtherAgentsIntact verifies that
+// deleting an agent removes only its own per-agent RBAC and leaves the other agent's RBAC untouched.
+func TestLanguageAgentController_DeletionCleansPerAgentRBACLeavesOtherAgentsIntact(t *testing.T) {
 	scheme := testutil.SetupTestScheme(t)
 
 	deletingAgent := &langopv1alpha1.LanguageAgent{
@@ -748,13 +749,20 @@ func TestLanguageAgentController_DeletionKeepsRBACWhenOtherAgentsExist(t *testin
 		},
 	}
 
-	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "language-agent", Namespace: "default"}}
-	role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "language-agent", Namespace: "default"}}
-	rb := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "language-agent", Namespace: "default"}}
+	deletingSAName := GenerateServiceAccountName(deletingAgent.Name)
+	otherSAName := GenerateServiceAccountName(otherAgent.Name)
+
+	// Pre-create per-agent RBAC for both agents.
+	deletingSA := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: deletingSAName, Namespace: "default"}}
+	deletingRole := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: deletingSAName, Namespace: "default"}}
+	deletingRB := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: deletingSAName, Namespace: "default"}}
+	otherSA := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: otherSAName, Namespace: "default"}}
+	otherRole := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: otherSAName, Namespace: "default"}}
+	otherRB := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: otherSAName, Namespace: "default"}}
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(deletingAgent, otherAgent, sa, role, rb).
+		WithObjects(deletingAgent, otherAgent, deletingSA, deletingRole, deletingRB, otherSA, otherRole, otherRB).
 		WithStatusSubresource(deletingAgent).
 		Build()
 
@@ -778,21 +786,33 @@ func TestLanguageAgentController_DeletionKeepsRBACWhenOtherAgentsExist(t *testin
 		t.Fatalf("Reconcile failed: %v", err)
 	}
 
-	// Shared RBAC resources must remain because other-agent still exists.
-	if err := fakeClient.Get(ctx, types.NamespacedName{Name: "language-agent", Namespace: "default"}, &corev1.ServiceAccount{}); err != nil {
-		t.Errorf("Expected ServiceAccount/language-agent to still exist, got: %v", err)
+	// Deleting agent's per-agent RBAC must be cleaned up.
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: deletingSAName, Namespace: "default"}, &corev1.ServiceAccount{}); !errors.IsNotFound(err) {
+		t.Errorf("Expected ServiceAccount/%s to be deleted, got: %v", deletingSAName, err)
 	}
-	if err := fakeClient.Get(ctx, types.NamespacedName{Name: "language-agent", Namespace: "default"}, &rbacv1.Role{}); err != nil {
-		t.Errorf("Expected Role/language-agent to still exist, got: %v", err)
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: deletingSAName, Namespace: "default"}, &rbacv1.Role{}); !errors.IsNotFound(err) {
+		t.Errorf("Expected Role/%s to be deleted, got: %v", deletingSAName, err)
 	}
-	if err := fakeClient.Get(ctx, types.NamespacedName{Name: "language-agent", Namespace: "default"}, &rbacv1.RoleBinding{}); err != nil {
-		t.Errorf("Expected RoleBinding/language-agent to still exist, got: %v", err)
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: deletingSAName, Namespace: "default"}, &rbacv1.RoleBinding{}); !errors.IsNotFound(err) {
+		t.Errorf("Expected RoleBinding/%s to be deleted, got: %v", deletingSAName, err)
+	}
+
+	// Other agent's per-agent RBAC must remain untouched.
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: otherSAName, Namespace: "default"}, &corev1.ServiceAccount{}); err != nil {
+		t.Errorf("Expected ServiceAccount/%s to still exist, got: %v", otherSAName, err)
+	}
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: otherSAName, Namespace: "default"}, &rbacv1.Role{}); err != nil {
+		t.Errorf("Expected Role/%s to still exist, got: %v", otherSAName, err)
+	}
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: otherSAName, Namespace: "default"}, &rbacv1.RoleBinding{}); err != nil {
+		t.Errorf("Expected RoleBinding/%s to still exist, got: %v", otherSAName, err)
 	}
 }
 
-// TestLanguageAgentController_DeletionCleansRBACWhenOtherAgentAlsoDeleting verifies that shared
-// RBAC resources ARE deleted when the only other agent in the namespace is itself being deleted.
-func TestLanguageAgentController_DeletionCleansRBACWhenOtherAgentAlsoDeleting(t *testing.T) {
+// TestLanguageAgentController_DeletionCleansPerAgentRBACAlwaysDeletesOwn verifies that an
+// agent's own per-agent RBAC is always cleaned up on deletion, even when other agents are
+// also being deleted concurrently.
+func TestLanguageAgentController_DeletionCleansPerAgentRBACAlwaysDeletesOwn(t *testing.T) {
 	scheme := testutil.SetupTestScheme(t)
 
 	deletingAgent := &langopv1alpha1.LanguageAgent{
@@ -808,7 +828,6 @@ func TestLanguageAgentController_DeletionCleansRBACWhenOtherAgentAlsoDeleting(t 
 			Instructions: "Agent being deleted",
 		},
 	}
-	// This agent is also being deleted — must not count as "live"
 	otherDeletingAgent := &langopv1alpha1.LanguageAgent{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "other-agent-also-deleting",
@@ -823,9 +842,10 @@ func TestLanguageAgentController_DeletionCleansRBACWhenOtherAgentAlsoDeleting(t 
 		},
 	}
 
-	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "language-agent", Namespace: "default"}}
-	role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "language-agent", Namespace: "default"}}
-	rb := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "language-agent", Namespace: "default"}}
+	saName := GenerateServiceAccountName(deletingAgent.Name)
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: "default"}}
+	role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: "default"}}
+	rb := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: "default"}}
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -853,15 +873,15 @@ func TestLanguageAgentController_DeletionCleansRBACWhenOtherAgentAlsoDeleting(t 
 		t.Fatalf("Reconcile failed: %v", err)
 	}
 
-	// Shared RBAC resources must be deleted because no live agent remains.
-	if err := fakeClient.Get(ctx, types.NamespacedName{Name: "language-agent", Namespace: "default"}, &corev1.ServiceAccount{}); !errors.IsNotFound(err) {
-		t.Errorf("Expected ServiceAccount/language-agent to be deleted, got: %v", err)
+	// The deleting agent's per-agent RBAC must always be cleaned up.
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: saName, Namespace: "default"}, &corev1.ServiceAccount{}); !errors.IsNotFound(err) {
+		t.Errorf("Expected ServiceAccount/%s to be deleted, got: %v", saName, err)
 	}
-	if err := fakeClient.Get(ctx, types.NamespacedName{Name: "language-agent", Namespace: "default"}, &rbacv1.Role{}); !errors.IsNotFound(err) {
-		t.Errorf("Expected Role/language-agent to be deleted, got: %v", err)
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: saName, Namespace: "default"}, &rbacv1.Role{}); !errors.IsNotFound(err) {
+		t.Errorf("Expected Role/%s to be deleted, got: %v", saName, err)
 	}
-	if err := fakeClient.Get(ctx, types.NamespacedName{Name: "language-agent", Namespace: "default"}, &rbacv1.RoleBinding{}); !errors.IsNotFound(err) {
-		t.Errorf("Expected RoleBinding/language-agent to be deleted, got: %v", err)
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: saName, Namespace: "default"}, &rbacv1.RoleBinding{}); !errors.IsNotFound(err) {
+		t.Errorf("Expected RoleBinding/%s to be deleted, got: %v", saName, err)
 	}
 }
 
@@ -1573,31 +1593,32 @@ func TestLanguageAgentController_ServiceAccountCreation(t *testing.T) {
 		t.Fatalf("Reconcile failed: %v", err)
 	}
 
-	// Verify ServiceAccount created in agent namespace
+	// Verify per-agent ServiceAccount created with expected name.
+	saName := GenerateServiceAccountName(agent.Name)
 	sa := &corev1.ServiceAccount{}
-	if err := fakeClient.Get(ctx, types.NamespacedName{Name: "language-agent", Namespace: agent.Namespace}, sa); err != nil {
-		t.Fatalf("Expected ServiceAccount 'language-agent' to exist in namespace %s: %v", agent.Namespace, err)
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: saName, Namespace: agent.Namespace}, sa); err != nil {
+		t.Fatalf("Expected ServiceAccount %q to exist in namespace %s: %v", saName, agent.Namespace, err)
 	}
 
-	// Verify namespace-scoped Role created
+	// Verify namespace-scoped Role created with default rules.
 	role := &rbacv1.Role{}
-	if err := fakeClient.Get(ctx, types.NamespacedName{Name: "language-agent", Namespace: agent.Namespace}, role); err != nil {
-		t.Fatalf("Expected Role 'language-agent' to exist in namespace %s: %v", agent.Namespace, err)
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: saName, Namespace: agent.Namespace}, role); err != nil {
+		t.Fatalf("Expected Role %q to exist in namespace %s: %v", saName, agent.Namespace, err)
 	}
 	if len(role.Rules) == 0 {
 		t.Errorf("Expected Role to have at least one rule")
 	}
 
-	// Verify namespace-scoped RoleBinding created and points to the Role (not the operator ClusterRole)
+	// Verify namespace-scoped RoleBinding created and points to the Role (not the operator ClusterRole).
 	rb := &rbacv1.RoleBinding{}
-	if err := fakeClient.Get(ctx, types.NamespacedName{Name: "language-agent", Namespace: agent.Namespace}, rb); err != nil {
-		t.Fatalf("Expected RoleBinding 'language-agent' to exist in namespace %s: %v", agent.Namespace, err)
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: saName, Namespace: agent.Namespace}, rb); err != nil {
+		t.Fatalf("Expected RoleBinding %q to exist in namespace %s: %v", saName, agent.Namespace, err)
 	}
 	if rb.RoleRef.Kind != "Role" {
 		t.Errorf("Expected RoleBinding RoleRef.Kind 'Role', got %q", rb.RoleRef.Kind)
 	}
-	if rb.RoleRef.Name != "language-agent" {
-		t.Errorf("Expected RoleBinding RoleRef.Name 'language-agent', got %q", rb.RoleRef.Name)
+	if rb.RoleRef.Name != saName {
+		t.Errorf("Expected RoleBinding RoleRef.Name %q, got %q", saName, rb.RoleRef.Name)
 	}
 }
 
@@ -1632,20 +1653,131 @@ func TestLanguageAgentController_CustomServiceAccount(t *testing.T) {
 	_, err = reconciler.Reconcile(ctx, req)
 	require.NoError(t, err)
 
-	// No default RBAC resources should be created when a custom SA is specified.
-	err = fakeClient.Get(ctx, types.NamespacedName{Name: "language-agent", Namespace: agent.Namespace}, &corev1.ServiceAccount{})
-	assert.True(t, errors.IsNotFound(err), "expected no ServiceAccount 'language-agent', got: %v", err)
+	// No operator-managed RBAC resources should be created when a custom SA is specified.
+	defaultSAName := GenerateServiceAccountName(agent.Name)
+	err = fakeClient.Get(ctx, types.NamespacedName{Name: defaultSAName, Namespace: agent.Namespace}, &corev1.ServiceAccount{})
+	assert.True(t, errors.IsNotFound(err), "expected no ServiceAccount %q, got: %v", defaultSAName, err)
 
-	err = fakeClient.Get(ctx, types.NamespacedName{Name: "language-agent", Namespace: agent.Namespace}, &rbacv1.Role{})
-	assert.True(t, errors.IsNotFound(err), "expected no Role 'language-agent', got: %v", err)
+	err = fakeClient.Get(ctx, types.NamespacedName{Name: defaultSAName, Namespace: agent.Namespace}, &rbacv1.Role{})
+	assert.True(t, errors.IsNotFound(err), "expected no Role %q, got: %v", defaultSAName, err)
 
-	err = fakeClient.Get(ctx, types.NamespacedName{Name: "language-agent", Namespace: agent.Namespace}, &rbacv1.RoleBinding{})
-	assert.True(t, errors.IsNotFound(err), "expected no RoleBinding 'language-agent', got: %v", err)
+	err = fakeClient.Get(ctx, types.NamespacedName{Name: defaultSAName, Namespace: agent.Namespace}, &rbacv1.RoleBinding{})
+	assert.True(t, errors.IsNotFound(err), "expected no RoleBinding %q, got: %v", defaultSAName, err)
 
 	// Deployment must use the custom service account name.
 	deployment := &appsv1.Deployment{}
 	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, deployment))
 	assert.Equal(t, "custom-sa", deployment.Spec.Template.Spec.ServiceAccountName)
+}
+
+func TestLanguageAgentController_ServiceAccountAnnotations(t *testing.T) {
+	scheme := testutil.SetupTestScheme(t)
+
+	agent := &langopv1alpha1.LanguageAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "annotated-agent",
+			Namespace: "default",
+		},
+		Spec: langopv1alpha1.LanguageAgentSpec{
+			Image: "ghcr.io/language-operator/agent:latest",
+			Deployment: langopv1alpha1.DeploymentSpec{
+				ServiceAccountAnnotations: map[string]string{
+					"eks.amazonaws.com/role-arn": "arn:aws:iam::123456789012:role/my-role",
+					"iam.gke.io/service-account": "my-gsa@my-project.iam.gserviceaccount.com",
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gen.ReadyCluster("default"), agent).
+		WithStatusSubresource(agent).
+		Build()
+
+	reconciler := &LanguageAgentReconciler{
+		Client:          fakeClient,
+		Scheme:          scheme,
+		Log:             logr.Discard(),
+		Recorder:        &record.FakeRecorder{},
+		RegistryManager: &mockRegistryManager{},
+	}
+
+	ctx := context.Background()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}}
+	_, err := reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	saName := GenerateServiceAccountName(agent.Name)
+	sa := &corev1.ServiceAccount{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: saName, Namespace: agent.Namespace}, sa))
+
+	assert.Equal(t, "arn:aws:iam::123456789012:role/my-role", sa.Annotations["eks.amazonaws.com/role-arn"])
+	assert.Equal(t, "my-gsa@my-project.iam.gserviceaccount.com", sa.Annotations["iam.gke.io/service-account"])
+}
+
+func TestLanguageAgentController_RoleRules(t *testing.T) {
+	scheme := testutil.SetupTestScheme(t)
+
+	agent := &langopv1alpha1.LanguageAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "custom-rules-agent",
+			Namespace: "default",
+		},
+		Spec: langopv1alpha1.LanguageAgentSpec{
+			Image: "ghcr.io/language-operator/agent:latest",
+			Deployment: langopv1alpha1.DeploymentSpec{
+				RoleRules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"secrets"},
+						Verbs:     []string{"get"},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gen.ReadyCluster("default"), agent).
+		WithStatusSubresource(agent).
+		Build()
+
+	reconciler := &LanguageAgentReconciler{
+		Client:          fakeClient,
+		Scheme:          scheme,
+		Log:             logr.Discard(),
+		Recorder:        &record.FakeRecorder{},
+		RegistryManager: &mockRegistryManager{},
+	}
+
+	ctx := context.Background()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}}
+	_, err := reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	saName := GenerateServiceAccountName(agent.Name)
+	role := &rbacv1.Role{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: saName, Namespace: agent.Namespace}, role))
+
+	// Default rules (configmaps, pods) must still be present.
+	var hasConfigMaps, hasPods, hasSecrets bool
+	for _, rule := range role.Rules {
+		for _, res := range rule.Resources {
+			switch res {
+			case "configmaps":
+				hasConfigMaps = true
+			case "pods":
+				hasPods = true
+			case "secrets":
+				hasSecrets = true
+			}
+		}
+	}
+	assert.True(t, hasConfigMaps, "expected default configmaps rule in Role")
+	assert.True(t, hasPods, "expected default pods rule in Role")
+	assert.True(t, hasSecrets, "expected custom secrets rule to be appended to Role")
 }
 
 // --- Group 1: Pure/stateless functions ---
@@ -5034,9 +5166,9 @@ func TestLanguageAgentController_ManagedResources(t *testing.T) {
 		assert.True(t, hasMR(mr, "Deployment", "base-agent"), "Deployment must be present")
 		assert.True(t, hasMR(mr, "Service", "base-agent"), "Service must be present")
 		assert.True(t, hasMR(mr, "ConfigMap", GenerateConfigMapName("base-agent", "agent")), "ConfigMap must be present")
-		assert.True(t, hasMR(mr, "ServiceAccount", "language-agent"), "ServiceAccount must be present")
-		assert.True(t, hasMR(mr, "Role", "language-agent"), "Role must be present")
-		assert.True(t, hasMR(mr, "RoleBinding", "language-agent"), "RoleBinding must be present")
+		assert.True(t, hasMR(mr, "ServiceAccount", GenerateServiceAccountName("base-agent")), "ServiceAccount must be present")
+		assert.True(t, hasMR(mr, "Role", GenerateServiceAccountName("base-agent")), "Role must be present")
+		assert.True(t, hasMR(mr, "RoleBinding", GenerateServiceAccountName("base-agent")), "RoleBinding must be present")
 
 		assert.False(t, hasMR(mr, "PersistentVolumeClaim", GeneratePVCName("base-agent")), "PVC must not be present when workspace disabled")
 		assert.False(t, hasMR(mr, "Secret", "base-agent-runtime"), "Secret must not be present without creds")

--- a/src/controllers/utils.go
+++ b/src/controllers/utils.go
@@ -344,6 +344,11 @@ func GenerateConfigMapName(resourceName, suffix string) string {
 	return fmt.Sprintf("%s-%s", resourceName, suffix)
 }
 
+// GenerateServiceAccountName returns the name of the operator-managed ServiceAccount for an agent.
+func GenerateServiceAccountName(agentName string) string {
+	return "language-agent-" + agentName
+}
+
 // GeneratePVCName returns the PVC name for an agent's workspace volume.
 func GeneratePVCName(agentName string) string {
 	return agentName + "-workspace"


### PR DESCRIPTION
Closes #715

## Summary

- Each `LanguageAgent` now gets its own `ServiceAccount`, `Role`, and `RoleBinding` named `language-agent-<agent-name>` instead of a shared `language-agent` per namespace
- Added `spec.deployment.serviceAccountAnnotations` to `DeploymentSpec` — annotations merged onto the operator-managed SA, enabling cloud workload identity (AWS IRSA, GCP WI, AKS WI)
- Added `spec.deployment.roleRules` to `DeploymentSpec` — additional RBAC policy rules appended to the default Role (configmaps get/list, pods get/list/watch)
- Both fields are ignored when `spec.deployment.serviceAccountName` is set (custom SA path unchanged)
- Cleanup on deletion is now per-agent (no more "last agent in namespace" check)

## Migration note

Existing `language-agent` shared SA/Role/RoleBinding will be orphaned on upgrade. New per-agent resources are created automatically on next reconcile. Old resources can be cleaned up manually.