### PR TITLE
fix: remove Namespace field from SecretReference — cross-namespace secrets not supported

### DIFF
--- a/chart/templates/crds/langop.io_languagemodels.yaml
+++ b/chart/templates/crds/langop.io_languagemodels.yaml
@@ -67,10 +67,6 @@ spec:
                   name:
                     description: Name is the name of the secret
                     type: string
-                  namespace:
-                    description: Namespace is the namespace of the secret (defaults
-                      to same namespace as LanguageModel)
-                    type: string
                 required:
                 - name
                 type: object

--- a/src/api/v1alpha1/languagemodel_types.go
+++ b/src/api/v1alpha1/languagemodel_types.go
@@ -41,10 +41,6 @@ type SecretReference struct {
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 
-	// Namespace is the namespace of the secret (defaults to same namespace as LanguageModel)
-	// +optional
-	Namespace string `json:"namespace,omitempty"`
-
 	// Key is the key within the secret containing the value
 	// +kubebuilder:default="api-key"
 	// +optional

--- a/src/config/crd/bases/langop.io_languagemodels.yaml
+++ b/src/config/crd/bases/langop.io_languagemodels.yaml
@@ -65,10 +65,6 @@ spec:
                   name:
                     description: Name is the name of the secret
                     type: string
-                  namespace:
-                    description: Namespace is the namespace of the secret (defaults
-                      to same namespace as LanguageModel)
-                    type: string
                 required:
                 - name
                 type: object

--- a/src/controllers/languagemodel_controller.go
+++ b/src/controllers/languagemodel_controller.go
@@ -129,15 +129,11 @@ func (r *LanguageModelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Validate apiKeySecretRef if set — surface a missing Secret as Phase: Failed
 	// rather than letting the gateway fail silently at runtime.
 	if model.Spec.APIKeySecretRef != nil {
-		secretNS := model.Spec.APIKeySecretRef.Namespace
-		if secretNS == "" {
-			secretNS = model.Namespace
-		}
 		secret := &corev1.Secret{}
-		if err := r.Get(ctx, types.NamespacedName{Name: model.Spec.APIKeySecretRef.Name, Namespace: secretNS}, secret); err != nil {
+		if err := r.Get(ctx, types.NamespacedName{Name: model.Spec.APIKeySecretRef.Name, Namespace: model.Namespace}, secret); err != nil {
 			var msg string
 			if apierrors.IsNotFound(err) {
-				msg = fmt.Sprintf("secret %q not found in namespace %q", model.Spec.APIKeySecretRef.Name, secretNS)
+				msg = fmt.Sprintf("secret %q not found in namespace %q", model.Spec.APIKeySecretRef.Name, model.Namespace)
 			} else {
 				msg = fmt.Sprintf("failed to get apiKeySecretRef: %v", err)
 			}

--- a/src/controllers/languagemodel_controller_test.go
+++ b/src/controllers/languagemodel_controller_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"strings"
+
 	"github.com/go-logr/logr"
 	langopv1alpha1 "github.com/language-operator/language-operator/api/v1alpha1"
 	"github.com/language-operator/language-operator/controllers/testutil"
@@ -317,6 +319,66 @@ func TestLanguageModelController_MissingAPIKeySecret(t *testing.T) {
 	}
 	if readyCond.Reason != langopv1alpha1.ReasonSecretNotFound {
 		t.Errorf("Expected reason %q, got %q", langopv1alpha1.ReasonSecretNotFound, readyCond.Reason)
+	}
+}
+
+// TestLanguageModelController_APIKeySecretRefLookedUpInModelNamespace verifies that
+// the secret referenced by apiKeySecretRef is always looked up in the model's own
+// namespace. A secret in a different namespace must not satisfy the check — the
+// cluster gateway pod can only mount secrets from its own namespace, so cross-
+// namespace references would silently fail at runtime.
+func TestLanguageModelController_APIKeySecretRefLookedUpInModelNamespace(t *testing.T) {
+	scheme := testutil.SetupTestScheme(t)
+
+	model := gen.LanguageModel("test-model-ns", "model-ns",
+		gen.SetModelProvider("anthropic"),
+		gen.SetModelName("claude-3-5-sonnet-20241022"),
+		gen.SetModelAPIKeySecretRef("my-api-key", "api-key"),
+	)
+	model.Generation = 1
+
+	// Secret exists only in "other-ns", not in "model-ns".
+	secretInOtherNS := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-api-key", Namespace: "other-ns"},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(model, secretInOtherNS).
+		WithStatusSubresource(model).
+		Build()
+
+	reconciler := &LanguageModelReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+		Log:    logr.Discard(),
+	}
+
+	ctx := context.Background()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: model.Name, Namespace: model.Namespace}}
+
+	// First reconcile adds finalizer and writes Pending.
+	_, _ = reconciler.Reconcile(ctx, req)
+
+	// Second reconcile should fail: secret is in "other-ns", not "model-ns".
+	_, err := reconciler.Reconcile(ctx, req)
+	if err == nil {
+		t.Fatal("Expected error: secret in other namespace should not satisfy apiKeySecretRef validation")
+	}
+
+	updated := &langopv1alpha1.LanguageModel{}
+	if fetchErr := fakeClient.Get(ctx, types.NamespacedName{Name: model.Name, Namespace: model.Namespace}, updated); fetchErr != nil {
+		t.Fatalf("Failed to fetch model: %v", fetchErr)
+	}
+	if updated.Status.Phase != "Failed" {
+		t.Errorf("Expected phase 'Failed', got %q", updated.Status.Phase)
+	}
+	// Error message must name the model's namespace, not "other-ns".
+	if updated.Status.Message == "" {
+		t.Fatal("Expected non-empty status message")
+	}
+	if !strings.Contains(updated.Status.Message, "model-ns") {
+		t.Errorf("Expected error message to reference model namespace %q, got %q", "model-ns", updated.Status.Message)
 	}
 }
 


### PR DESCRIPTION
Closes #749