### PR TITLE
feat: add namespace conflict and port range validation to LanguageCluster webhook

### DIFF
--- a/src/api/v1alpha1/languagecluster_webhook.go
+++ b/src/api/v1alpha1/languagecluster_webhook.go
@@ -21,10 +21,14 @@ import (
 	"fmt"
 	"strings"
 
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-
+	"github.com/language-operator/language-operator/pkg/labels"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 //+kubebuilder:webhook:path=/validate-langop-io-v1alpha1-languagecluster,mutating=false,failurePolicy=fail,sideEffects=None,groups=langop.io,resources=languageclusters,verbs=create;update,versions=v1alpha1,name=vlanguagecluster.kb.io,admissionReviewVersions=v1
@@ -33,13 +37,18 @@ import (
 // LanguageCluster is cluster-scoped, so no cluster-membership check is needed.
 //
 // +kubebuilder:object:generate=false
-type LanguageClusterWebhook struct{}
+type LanguageClusterWebhook struct {
+	client.Client
+}
 
 var _ admission.Validator[*LanguageCluster] = &LanguageClusterWebhook{}
 
 // ValidateCreate implements admission.Validator
-func (h *LanguageClusterWebhook) ValidateCreate(_ context.Context, lc *LanguageCluster) (admission.Warnings, error) {
-	return nil, lc.validateSpec()
+func (h *LanguageClusterWebhook) ValidateCreate(ctx context.Context, lc *LanguageCluster) (admission.Warnings, error) {
+	if err := lc.validateSpec(); err != nil {
+		return nil, err
+	}
+	return nil, h.validateNamespaceNotClaimed(ctx, lc)
 }
 
 // ValidateUpdate implements admission.Validator
@@ -62,12 +71,59 @@ func (lc *LanguageCluster) validateSpec() error {
 			return fmt.Errorf("spec.domain: %q is not a valid DNS subdomain: %s", lc.Spec.Domain, strings.Join(errs, "; "))
 		}
 	}
+	if err := validateNetworkPortPolicies(lc.Spec.NetworkPolicies); err != nil {
+		return err
+	}
 	return nil
+}
+
+// validateNetworkPortPolicies validates that all port numbers in networkPolicies are in [1, 65535].
+func validateNetworkPortPolicies(policies *AgentNetworkPolicies) error {
+	if policies == nil {
+		return nil
+	}
+	for i, rule := range policies.Ingress {
+		for j, p := range rule.Ports {
+			if p.Port < 1 || p.Port > 65535 {
+				return fmt.Errorf("spec.networkPolicies.ingress[%d].ports[%d].port: %d is not in the valid port range [1, 65535]", i, j, p.Port)
+			}
+		}
+	}
+	for i, rule := range policies.Egress {
+		for j, p := range rule.Ports {
+			if p.Port < 1 || p.Port > 65535 {
+				return fmt.Errorf("spec.networkPolicies.egress[%d].ports[%d].port: %d is not in the valid port range [1, 65535]", i, j, p.Port)
+			}
+		}
+	}
+	return nil
+}
+
+// validateNamespaceNotClaimed rejects a new LanguageCluster if a namespace with the same name
+// already exists but is not managed by language-operator. This prevents the operator from
+// silently taking over pre-existing namespaces.
+func (h *LanguageClusterWebhook) validateNamespaceNotClaimed(ctx context.Context, lc *LanguageCluster) error {
+	if h.Client == nil {
+		return nil
+	}
+	ns := &corev1.Namespace{}
+	err := h.Client.Get(ctx, types.NamespacedName{Name: lc.Name}, ns)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to check namespace %q: %w", lc.Name, err)
+	}
+	if v, ok := ns.Labels[labels.LabelKeyLangopCluster]; ok && v == lc.Name {
+		return nil
+	}
+	return fmt.Errorf("namespace %q already exists and is not managed by language-operator; "+
+		"choose a different name or delete the existing namespace first", lc.Name)
 }
 
 // SetupLanguageClusterWebhookWithManager registers the LanguageCluster validating webhook.
 func SetupLanguageClusterWebhookWithManager(mgr ctrl.Manager) error {
-	h := &LanguageClusterWebhook{}
+	h := &LanguageClusterWebhook{Client: mgr.GetClient()}
 	return ctrl.NewWebhookManagedBy(mgr, &LanguageCluster{}).
 		WithValidator(h).
 		Complete()

--- a/src/api/v1alpha1/languagecluster_webhook_test.go
+++ b/src/api/v1alpha1/languagecluster_webhook_test.go
@@ -21,7 +21,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/language-operator/language-operator/pkg/labels"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestLanguageClusterValidateSpec(t *testing.T) {
@@ -193,5 +197,111 @@ func TestLanguageClusterWebhookValidateDelete(t *testing.T) {
 	_, err := h.ValidateDelete(context.Background(), lc)
 	if err != nil {
 		t.Errorf("ValidateDelete() unexpected error: %v", err)
+	}
+}
+
+func newFakeWebhook(objs ...runtime.Object) *LanguageClusterWebhook {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = AddToScheme(scheme)
+	b := fake.NewClientBuilder().WithScheme(scheme)
+	for _, o := range objs {
+		b = b.WithRuntimeObjects(o)
+	}
+	return &LanguageClusterWebhook{Client: b.Build()}
+}
+
+func TestLanguageClusterWebhookNamespaceConflict(t *testing.T) {
+	lc := &LanguageCluster{ObjectMeta: metav1.ObjectMeta{Name: "my-cluster"}}
+
+	t.Run("no existing namespace — accepted", func(t *testing.T) {
+		h := newFakeWebhook()
+		_, err := h.ValidateCreate(context.Background(), lc)
+		if err != nil {
+			t.Errorf("ValidateCreate() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("langop-owned namespace — accepted", func(t *testing.T) {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "my-cluster",
+				Labels: map[string]string{labels.LabelKeyLangopCluster: "my-cluster"},
+			},
+		}
+		h := newFakeWebhook(ns)
+		_, err := h.ValidateCreate(context.Background(), lc)
+		if err != nil {
+			t.Errorf("ValidateCreate() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("unmanaged namespace with same name — rejected", func(t *testing.T) {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-cluster"},
+		}
+		h := newFakeWebhook(ns)
+		_, err := h.ValidateCreate(context.Background(), lc)
+		if err == nil {
+			t.Error("ValidateCreate() expected error for unmanaged namespace conflict, got nil")
+		} else if !strings.Contains(err.Error(), "already exists") {
+			t.Errorf("ValidateCreate() error = %q, want to contain %q", err.Error(), "already exists")
+		}
+	})
+
+	t.Run("namespace owned by different cluster — rejected", func(t *testing.T) {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "my-cluster",
+				Labels: map[string]string{labels.LabelKeyLangopCluster: "other-cluster"},
+			},
+		}
+		h := newFakeWebhook(ns)
+		_, err := h.ValidateCreate(context.Background(), lc)
+		if err == nil {
+			t.Error("ValidateCreate() expected error for namespace owned by different cluster, got nil")
+		}
+	})
+}
+
+func TestValidateNetworkPortPolicies(t *testing.T) {
+	mkIngress := func(port int32) *AgentNetworkPolicies {
+		return &AgentNetworkPolicies{
+			Ingress: []NetworkIngressRule{{
+				Ports: []NetworkPort{{Port: port}},
+			}},
+		}
+	}
+	mkEgress := func(port int32) *AgentNetworkPolicies {
+		return &AgentNetworkPolicies{
+			Egress: []NetworkEgressRule{{
+				Ports: []NetworkPort{{Port: port}},
+			}},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		policies *AgentNetworkPolicies
+		wantErr  bool
+	}{
+		{"nil policies", nil, false},
+		{"no ports", &AgentNetworkPolicies{}, false},
+		{"ingress port 1 (min)", mkIngress(1), false},
+		{"ingress port 65535 (max)", mkIngress(65535), false},
+		{"ingress port 8080", mkIngress(8080), false},
+		{"egress port 443", mkEgress(443), false},
+		{"ingress port 0 — invalid", mkIngress(0), true},
+		{"ingress port -1 — invalid", mkIngress(-1), true},
+		{"egress port 65536 — invalid", mkEgress(65536), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateNetworkPortPolicies(tt.policies)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateNetworkPortPolicies() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/src/api/v1alpha1/suite_test.go
+++ b/src/api/v1alpha1/suite_test.go
@@ -13,6 +13,7 @@ import (
 
 	langopv1alpha1 "github.com/language-operator/language-operator/api/v1alpha1"
 	"github.com/language-operator/language-operator/internal/testutil/gen"
+	langoplabels "github.com/language-operator/language-operator/pkg/labels"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -144,9 +145,10 @@ func buildScheme() *runtime.Scheme {
 // TestWebhookClusterMembership verifies that the admission webhook enforces
 // LanguageCluster namespace membership at create time.
 func TestWebhookClusterMembership(t *testing.T) {
-	// Cluster-managed namespace
+	// Cluster-managed namespace — label it so the new namespace-conflict webhook check accepts it
 	clusterNs := &corev1.Namespace{}
 	clusterNs.Name = "webhook-test-cluster"
+	clusterNs.Labels = map[string]string{langoplabels.LabelKeyLangopCluster: "webhook-test-cluster"}
 	if err := k8sClient.Create(ctx, clusterNs); err != nil && !errors.IsAlreadyExists(err) {
 		t.Fatalf("create cluster namespace: %v", err)
 	}
@@ -222,6 +224,7 @@ func TestWebhookClusterMembership(t *testing.T) {
 func TestWebhookClusterMembershipTool(t *testing.T) {
 	clusterNs := &corev1.Namespace{}
 	clusterNs.Name = "webhook-tool-cluster"
+	clusterNs.Labels = map[string]string{langoplabels.LabelKeyLangopCluster: "webhook-tool-cluster"}
 	if err := k8sClient.Create(ctx, clusterNs); err != nil && !errors.IsAlreadyExists(err) {
 		t.Fatalf("create cluster namespace: %v", err)
 	}
@@ -267,6 +270,7 @@ func TestWebhookClusterMembershipTool(t *testing.T) {
 func TestWebhookClusterMembershipModel(t *testing.T) {
 	clusterNs := &corev1.Namespace{}
 	clusterNs.Name = "webhook-model-cluster"
+	clusterNs.Labels = map[string]string{langoplabels.LabelKeyLangopCluster: "webhook-model-cluster"}
 	if err := k8sClient.Create(ctx, clusterNs); err != nil && !errors.IsAlreadyExists(err) {
 		t.Fatalf("create cluster namespace: %v", err)
 	}
@@ -312,6 +316,7 @@ func TestWebhookClusterMembershipModel(t *testing.T) {
 func TestWebhookClusterMembershipPersona(t *testing.T) {
 	clusterNs := &corev1.Namespace{}
 	clusterNs.Name = "webhook-persona-cluster"
+	clusterNs.Labels = map[string]string{langoplabels.LabelKeyLangopCluster: "webhook-persona-cluster"}
 	if err := k8sClient.Create(ctx, clusterNs); err != nil && !errors.IsAlreadyExists(err) {
 		t.Fatalf("create cluster namespace: %v", err)
 	}


### PR DESCRIPTION
Closes #809

Implements two missing validations identified in the PR #812 review:

1. **Namespace conflict check** (`ValidateCreate` only): rejects a new `LanguageCluster` if a namespace with the same name already exists but is not managed by language-operator. Prevents silent takeover of pre-existing namespaces. Adds `client.Client` to the webhook struct.

2. **Port range validation**: validates that all `NetworkPort.Port` values in `spec.networkPolicies.ingress[].ports[].port` and `spec.networkPolicies.egress[].ports[].port` are in `[1, 65535]`.

**Skipped**: `spec.gateway.image` registry validation — this field does not exist in `GatewaySpec`. The gateway image is configured via Helm chart values (`config.gateway.image`), not via the CR spec, so there is nothing to validate at admission time.

13 new tests added covering boundary values, conflict scenarios, and nil-safety.