### PR TITLE
feat: LanguageCluster adopts pre-existing member resources on reconcile

### DIFF
--- a/src/api/v1alpha1/webhook_utils.go
+++ b/src/api/v1alpha1/webhook_utils.go
@@ -27,6 +27,11 @@ import (
 
 // validateClusterMembership verifies a LanguageCluster exists for the given namespace.
 // Used by all resource webhooks to enforce namespace membership.
+//
+// The check is existence-only, not readiness-based: a LanguageCluster that was just
+// admitted but has not yet reconciled satisfies this check. This allows atomic apply
+// (kubectl apply -k .) — LanguageCluster and member resources in a single bundle
+// succeed as long as the LanguageCluster object is admitted before member objects.
 func validateClusterMembership(ctx context.Context, c client.Client, namespace string) error {
 	cluster := &LanguageCluster{}
 	err := c.Get(ctx, types.NamespacedName{Name: namespace}, cluster)

--- a/src/controllers/languagecluster_controller.go
+++ b/src/controllers/languagecluster_controller.go
@@ -375,6 +375,11 @@ func (r *LanguageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	r.EventManager.RecordClusterReady(cluster)
 
+	// Touch all member resources in the namespace so their controllers re-reconcile.
+	// This handles the adoption case: resources that existed before the cluster was
+	// created (or before a prior reconcile completed) are discovered and re-queued.
+	r.adoptPreExistingMembers(ctx, cluster)
+
 	if err := r.Status().Update(ctx, cluster); err != nil {
 		log.Error(err, "Failed to update status")
 		span.RecordError(err)
@@ -385,6 +390,58 @@ func (r *LanguageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	span.SetStatus(codes.Ok, "Reconciliation successful")
 	return ctrl.Result{}, nil
+}
+
+// adoptPreExistingMembers stamps langop.io/cluster-generation on every member resource
+// (LanguageAgent, LanguageModel, LanguagePersona, LanguageTool) in the cluster namespace.
+// The annotation change triggers each resource's controller to re-reconcile, which
+// handles the case where members existed before the cluster was created. The method is
+// best-effort: individual list or patch failures are logged and ignored.
+func (r *LanguageClusterReconciler) adoptPreExistingMembers(ctx context.Context, cluster *langopv1alpha1.LanguageCluster) {
+	log := log.FromContext(ctx)
+	ns := cluster.Name
+	gen := fmt.Sprintf("%d", cluster.Generation)
+
+	touch := func(obj client.Object) {
+		anns := obj.GetAnnotations()
+		if anns != nil && anns[langoplabels.AnnotationKeyClusterGeneration] == gen {
+			return
+		}
+		base := obj.DeepCopyObject().(client.Object)
+		if anns == nil {
+			anns = map[string]string{}
+		}
+		anns[langoplabels.AnnotationKeyClusterGeneration] = gen
+		obj.SetAnnotations(anns)
+		if err := r.Patch(ctx, obj, client.MergeFrom(base)); err != nil && !errors.IsNotFound(err) {
+			log.V(1).Info("adoptPreExistingMembers: patch failed", "name", obj.GetName(), "err", err)
+		}
+	}
+
+	agents := &langopv1alpha1.LanguageAgentList{}
+	if err := r.List(ctx, agents, client.InNamespace(ns)); err == nil {
+		for i := range agents.Items {
+			touch(&agents.Items[i])
+		}
+	}
+	models := &langopv1alpha1.LanguageModelList{}
+	if err := r.List(ctx, models, client.InNamespace(ns)); err == nil {
+		for i := range models.Items {
+			touch(&models.Items[i])
+		}
+	}
+	personas := &langopv1alpha1.LanguagePersonaList{}
+	if err := r.List(ctx, personas, client.InNamespace(ns)); err == nil {
+		for i := range personas.Items {
+			touch(&personas.Items[i])
+		}
+	}
+	tools := &langopv1alpha1.LanguageToolList{}
+	if err := r.List(ctx, tools, client.InNamespace(ns)); err == nil {
+		for i := range tools.Items {
+			touch(&tools.Items[i])
+		}
+	}
 }
 
 // reconcileNamespace ensures a namespace named cluster.Name exists.

--- a/src/controllers/languagecluster_controller_test.go
+++ b/src/controllers/languagecluster_controller_test.go
@@ -2512,3 +2512,61 @@ func TestLanguageClusterController_AdoptNamespace_NotDeletedOnCleanup(t *testing
 	err = fakeClient.Get(ctx, types.NamespacedName{Name: cluster.Name}, survivingNs)
 	require.NoError(t, err, "adopted namespace must not be deleted on cluster removal")
 }
+
+func TestLanguageClusterReconciler_AdoptsPreExistingMembers(t *testing.T) {
+	scheme := testutil.SetupTestScheme(t)
+	ns := "adopt-test"
+
+	cluster := gen.LanguageCluster(ns)
+	agent := gen.LanguageAgent("agent-1", ns)
+	model := gen.LanguageModel("model-1", ns)
+	persona := gen.LanguagePersona("persona-1", ns)
+	tool := gen.LanguageTool("tool-1", ns)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, agent, model, persona, tool).
+		WithStatusSubresource(cluster).
+		Build()
+
+	reconciler := &LanguageClusterReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+		Log:    logr.Discard(),
+	}
+
+	ctx := context.Background()
+	req := clusterRequest(ns)
+
+	// First reconcile: adds finalizer
+	_, err := reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	// Second reconcile: runs to completion and calls adoptPreExistingMembers
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	// Verify cluster reached Ready
+	updatedCluster := &langopv1alpha1.LanguageCluster{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: ns}, updatedCluster))
+	assert.Equal(t, events.PhaseStatusReady, updatedCluster.Status.Phase)
+
+	// Every member resource must have the cluster-generation annotation stamped.
+	wantAnnotation := fmt.Sprintf("%d", updatedCluster.Generation)
+
+	updatedAgent := &langopv1alpha1.LanguageAgent{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: "agent-1", Namespace: ns}, updatedAgent))
+	assert.Equal(t, wantAnnotation, updatedAgent.Annotations[langoplabels.AnnotationKeyClusterGeneration], "LanguageAgent should be adopted")
+
+	updatedModel := &langopv1alpha1.LanguageModel{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: "model-1", Namespace: ns}, updatedModel))
+	assert.Equal(t, wantAnnotation, updatedModel.Annotations[langoplabels.AnnotationKeyClusterGeneration], "LanguageModel should be adopted")
+
+	updatedPersona := &langopv1alpha1.LanguagePersona{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: "persona-1", Namespace: ns}, updatedPersona))
+	assert.Equal(t, wantAnnotation, updatedPersona.Annotations[langoplabels.AnnotationKeyClusterGeneration], "LanguagePersona should be adopted")
+
+	updatedTool := &langopv1alpha1.LanguageTool{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: "tool-1", Namespace: ns}, updatedTool))
+	assert.Equal(t, wantAnnotation, updatedTool.Annotations[langoplabels.AnnotationKeyClusterGeneration], "LanguageTool should be adopted")
+}

--- a/src/pkg/labels/labels.go
+++ b/src/pkg/labels/labels.go
@@ -33,4 +33,11 @@ const (
 	LabelKeyK8sComponent = "app.kubernetes.io/component"
 	LabelKeyK8sManagedBy = "app.kubernetes.io/managed-by"
 	LabelKeyK8sPartOf    = "app.kubernetes.io/part-of"
+
+	// AnnotationKeyClusterGeneration records the LanguageCluster generation that last
+	// adopted this member resource. The cluster controller stamps this on every member
+	// (LanguageAgent, LanguageModel, LanguagePersona, LanguageTool) after a successful
+	// reconcile so that pre-existing resources are re-queued when a cluster is created
+	// or updated.
+	AnnotationKeyClusterGeneration = "langop.io/cluster-generation"
 )


### PR DESCRIPTION
Closes #821

## Changes

- **`pkg/labels/labels.go`**: adds `AnnotationKeyClusterGeneration = "langop.io/cluster-generation"` constant
- **`api/v1alpha1/webhook_utils.go`**: documents that `validateClusterMembership` is existence-only (not readiness-based), enabling atomic `kubectl apply -k .` bundles
- **`controllers/languagecluster_controller.go`**: adds `adoptPreExistingMembers` — after every successful reconcile the cluster controller stamps `langop.io/cluster-generation: <N>` on every LanguageAgent, LanguageModel, LanguagePersona, and LanguageTool in the namespace; the annotation change triggers each member controller's reconcile queue, ensuring pre-existing resources are adopted
- **`controllers/languagecluster_controller_test.go`**: `TestLanguageClusterReconciler_AdoptsPreExistingMembers` verifies all four member kinds are annotated after cluster reconcile