### PR TITLE
feat: fix claudeCode.apiKeyRef to honour api-key secret key convention

### DIFF
--- a/charts/language-operator/templates/crds/langop.io_languageagents.yaml
+++ b/charts/language-operator/templates/crds/langop.io_languageagents.yaml
@@ -79,12 +79,18 @@ spec:
                     type: string
                   apiKeyRef:
                     description: |-
-                      APIKeyRef references a Secret whose keys are injected via envFrom.
-                      The Secret must contain ANTHROPIC_API_KEY.
+                      APIKeyRef references a Secret containing the Anthropic API key.
+                      The operator reads the key specified by apiKeyRef.key (default "api-key")
+                      and injects it as ANTHROPIC_API_KEY into the agent container.
                       Mutually exclusive with APIKey.
                     properties:
+                      key:
+                        default: api-key
+                        description: Key is the key within the secret containing the
+                          value
+                        type: string
                       name:
-                        description: Name is the name of the Secret.
+                        description: Name is the name of the secret
                         type: string
                     required:
                     - name

--- a/docs/guides/claude-code.md
+++ b/docs/guides/claude-code.md
@@ -36,7 +36,7 @@ kubectl config set-context --current --namespace=demo-cluster
 
 ```bash
 kubectl create secret generic anthropic-credentials \
-  --from-literal=ANTHROPIC_API_KEY=sk-ant-your-key-here
+  --from-literal=api-key=sk-ant-your-key-here
 ```
 
 ### Deploy Claude Code
@@ -58,7 +58,7 @@ spec:
 EOF
 ```
 
-The `apiKeyRef` tells the operator to inject `ANTHROPIC_API_KEY` from your secret directly into the pod — traffic goes straight to Anthropic, bypassing the shared gateway.
+The `apiKeyRef` tells the operator to read the `api-key` key from your secret and inject it as `ANTHROPIC_API_KEY` into the pod — traffic goes straight to Anthropic, bypassing the shared gateway.
 
 ### Verify
 
@@ -87,7 +87,8 @@ Then open `http://localhost:8080` in your browser. You'll see Claude Code's inte
 
 | Field | Description |
 |-------|-------------|
-| `spec.claudeCode.apiKeyRef.name` | Secret containing `ANTHROPIC_API_KEY`. Recommended for direct Anthropic access. |
+| `spec.claudeCode.apiKeyRef.name` | Secret name containing the API key. The operator reads the key specified by `apiKeyRef.key` (default `api-key`) and injects it as `ANTHROPIC_API_KEY`. Recommended for direct Anthropic access. |
+| `spec.claudeCode.apiKeyRef.key` | Key within the secret (default: `api-key`). Override if your secret uses a different key name. |
 | `spec.claudeCode.apiKey` | Inline API key (stored in a managed Secret). Use `apiKeyRef` instead if the key is already in a Secret. |
 | `spec.claudeCode.enabled` | Set automatically by the `claude-code` runtime. No need to set this manually. |
 

--- a/src/api/v1alpha1/languageagent_types.go
+++ b/src/api/v1alpha1/languageagent_types.go
@@ -354,11 +354,12 @@ type ClaudeCodeConfig struct {
 	// +optional
 	APIKey string `json:"apiKey,omitempty"`
 
-	// APIKeyRef references a Secret whose keys are injected via envFrom.
-	// The Secret must contain ANTHROPIC_API_KEY.
+	// APIKeyRef references a Secret containing the Anthropic API key.
+	// The operator reads the key specified by apiKeyRef.key (default "api-key")
+	// and injects it as ANTHROPIC_API_KEY into the agent container.
 	// Mutually exclusive with APIKey.
 	// +optional
-	APIKeyRef *RuntimeSecretRef `json:"apiKeyRef,omitempty"`
+	APIKeyRef *SecretReference `json:"apiKeyRef,omitempty"`
 
 	// MaxTurns limits the number of agentic turns per request.
 	// Sets CLAUDE_CODE_MAX_TURNS in the agent container.

--- a/src/api/v1alpha1/zz_generated.deepcopy.go
+++ b/src/api/v1alpha1/zz_generated.deepcopy.go
@@ -163,7 +163,7 @@ func (in *ClaudeCodeConfig) DeepCopyInto(out *ClaudeCodeConfig) {
 	}
 	if in.APIKeyRef != nil {
 		in, out := &in.APIKeyRef, &out.APIKeyRef
-		*out = new(RuntimeSecretRef)
+		*out = new(SecretReference)
 		**out = **in
 	}
 	if in.MaxTurns != nil {

--- a/src/config/crd/bases/langop.io_languageagentruntimes.yaml
+++ b/src/config/crd/bases/langop.io_languageagentruntimes.yaml
@@ -67,12 +67,18 @@ spec:
                     type: string
                   apiKeyRef:
                     description: |-
-                      APIKeyRef references a Secret whose keys are injected via envFrom.
-                      The Secret must contain ANTHROPIC_API_KEY.
+                      APIKeyRef references a Secret containing the Anthropic API key.
+                      The operator reads the key specified by apiKeyRef.key (default "api-key")
+                      and injects it as ANTHROPIC_API_KEY into the agent container.
                       Mutually exclusive with APIKey.
                     properties:
+                      key:
+                        default: api-key
+                        description: Key is the key within the secret containing the
+                          value
+                        type: string
                       name:
-                        description: Name is the name of the Secret.
+                        description: Name is the name of the secret
                         type: string
                     required:
                     - name

--- a/src/config/crd/bases/langop.io_languageagents.yaml
+++ b/src/config/crd/bases/langop.io_languageagents.yaml
@@ -72,12 +72,18 @@ spec:
                     type: string
                   apiKeyRef:
                     description: |-
-                      APIKeyRef references a Secret whose keys are injected via envFrom.
-                      The Secret must contain ANTHROPIC_API_KEY.
+                      APIKeyRef references a Secret containing the Anthropic API key.
+                      The operator reads the key specified by apiKeyRef.key (default "api-key")
+                      and injects it as ANTHROPIC_API_KEY into the agent container.
                       Mutually exclusive with APIKey.
                     properties:
+                      key:
+                        default: api-key
+                        description: Key is the key within the secret containing the
+                          value
+                        type: string
                       name:
-                        description: Name is the name of the Secret.
+                        description: Name is the name of the secret
                         type: string
                     required:
                     - name

--- a/src/controllers/languageagent_claudecode_test.go
+++ b/src/controllers/languageagent_claudecode_test.go
@@ -200,7 +200,7 @@ func TestReconcileRuntimeSecret_ClaudeCode_InlineAPIKey(t *testing.T) {
 }
 
 func TestReconcileRuntimeSecret_ClaudeCode_APIKeyRef(t *testing.T) {
-	// claudeCode.apiKeyRef → envFrom reference added, no managed secret
+	// claudeCode.apiKeyRef → ANTHROPIC_API_KEY injected via secretKeyRef, no managed secret
 	agent := &langopv1alpha1.LanguageAgent{
 		ObjectMeta: metav1.ObjectMeta{Name: "cc-ref", Namespace: "default"},
 		Spec: langopv1alpha1.LanguageAgentSpec{
@@ -210,7 +210,7 @@ func TestReconcileRuntimeSecret_ClaudeCode_APIKeyRef(t *testing.T) {
 			},
 			ClaudeCode: &langopv1alpha1.ClaudeCodeConfig{
 				Enabled:   ptr.To(true),
-				APIKeyRef: &langopv1alpha1.RuntimeSecretRef{Name: "my-anthropic-secret"},
+				APIKeyRef: &langopv1alpha1.SecretReference{Name: "my-anthropic-secret"},
 			},
 		},
 	}
@@ -224,18 +224,56 @@ func TestReconcileRuntimeSecret_ClaudeCode_APIKeyRef(t *testing.T) {
 	}, secret)
 	assert.True(t, err != nil, "no managed runtime Secret when using APIKeyRef")
 
-	// envFrom reference is injected into workingAgent
+	// ANTHROPIC_API_KEY is injected via secretKeyRef with default key "api-key"
 	working := agent.DeepCopy()
 	err = reconciler.reconcileRuntimeSecret(context.Background(), agent, working)
 	require.NoError(t, err)
 
 	var found bool
-	for _, ef := range working.Spec.Deployment.EnvFrom {
-		if ef.SecretRef != nil && ef.SecretRef.Name == "my-anthropic-secret" {
+	for _, e := range working.Spec.Deployment.Env {
+		if e.Name == "ANTHROPIC_API_KEY" &&
+			e.ValueFrom != nil &&
+			e.ValueFrom.SecretKeyRef != nil &&
+			e.ValueFrom.SecretKeyRef.Name == "my-anthropic-secret" &&
+			e.ValueFrom.SecretKeyRef.Key == "api-key" {
 			found = true
 		}
 	}
-	assert.True(t, found, "envFrom references the APIKeyRef secret")
+	assert.True(t, found, "ANTHROPIC_API_KEY injected via secretKeyRef with default key 'api-key'")
+}
+
+func TestReconcileRuntimeSecret_ClaudeCode_APIKeyRef_CustomKey(t *testing.T) {
+	// claudeCode.apiKeyRef with explicit key → secretKeyRef uses that key
+	agent := &langopv1alpha1.LanguageAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "cc-ref-custom", Namespace: "default"},
+		Spec: langopv1alpha1.LanguageAgentSpec{
+			Image: "ghcr.io/language-operator/agent:latest",
+			Workspace: &langopv1alpha1.WorkspaceSpec{
+				Enabled: func() *bool { b := false; return &b }(),
+			},
+			ClaudeCode: &langopv1alpha1.ClaudeCodeConfig{
+				Enabled:   ptr.To(true),
+				APIKeyRef: &langopv1alpha1.SecretReference{Name: "my-anthropic-secret", Key: "ANTHROPIC_API_KEY"},
+			},
+		},
+	}
+
+	working := agent.DeepCopy()
+	reconciler, _ := reconcileClaudeCodeAgent(t, agent)
+	err := reconciler.reconcileRuntimeSecret(context.Background(), agent, working)
+	require.NoError(t, err)
+
+	var found bool
+	for _, e := range working.Spec.Deployment.Env {
+		if e.Name == "ANTHROPIC_API_KEY" &&
+			e.ValueFrom != nil &&
+			e.ValueFrom.SecretKeyRef != nil &&
+			e.ValueFrom.SecretKeyRef.Name == "my-anthropic-secret" &&
+			e.ValueFrom.SecretKeyRef.Key == "ANTHROPIC_API_KEY" {
+			found = true
+		}
+	}
+	assert.True(t, found, "ANTHROPIC_API_KEY injected via secretKeyRef with explicit key")
 }
 
 func TestReconcileRuntimeSecret_ClaudeCode_MaxTurns(t *testing.T) {

--- a/src/controllers/languageagent_config.go
+++ b/src/controllers/languageagent_config.go
@@ -511,9 +511,17 @@ func (r *LanguageAgentReconciler) reconcileRuntimeSecret(
 		if cc.APIKey != "" {
 			secretData["ANTHROPIC_API_KEY"] = []byte(cc.APIKey)
 		} else if cc.APIKeyRef != nil {
-			refEnvFrom = append(refEnvFrom, corev1.EnvFromSource{
-				SecretRef: &corev1.SecretEnvSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: cc.APIKeyRef.Name},
+			key := cc.APIKeyRef.Key
+			if key == "" {
+				key = "api-key"
+			}
+			extraEnv = append(extraEnv, corev1.EnvVar{
+				Name: "ANTHROPIC_API_KEY",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: cc.APIKeyRef.Name},
+						Key:                  key,
+					},
 				},
 			})
 		} else {

--- a/src/controllers/languageagent_controller_test.go
+++ b/src/controllers/languageagent_controller_test.go
@@ -1565,7 +1565,7 @@ func TestLanguageAgentController_ManagedResources(t *testing.T) {
 				Image: "ghcr.io/language-operator/agent:latest",
 				ClaudeCode: &langopv1alpha1.ClaudeCodeConfig{
 					Enabled:   &enabled,
-					APIKeyRef: &langopv1alpha1.RuntimeSecretRef{Name: "my-anthropic-secret"},
+					APIKeyRef: &langopv1alpha1.SecretReference{Name: "my-anthropic-secret"},
 				},
 			},
 		}


### PR DESCRIPTION
## Summary

- Changes `ClaudeCodeConfig.APIKeyRef` type from `*RuntimeSecretRef` to `*SecretReference`, adding an optional `key` field (default `"api-key"`) consistent with `LanguageModel.spec.apiKeySecretRef`
- Replaces `envFrom` injection (all secret keys exposed) with a targeted `secretKeyRef` that reads the specified key and injects it as `ANTHROPIC_API_KEY`
- Updates docs to use `--from-literal=api-key=...` to match the project-wide convention
- Regenerates CRD YAMLs with the new `apiKeyRef.key` field

Closes #846