### PR TITLE
chore: simplify examples to use spec.claudeCode.apiKeyRef

### DIFF
--- a/examples/language-operator-team/agent-supervisor.yaml
+++ b/examples/language-operator-team/agent-supervisor.yaml
@@ -40,13 +40,11 @@ spec:
             protocol: TCP
   workspace:
     size: 5Gi
+  claudeCode:
+    apiKeyRef:
+      name: anthropic-credentials
   deployment:
     env:
-      - name: ANTHROPIC_API_KEY
-        valueFrom:
-          secretKeyRef:
-            name: anthropic-credentials
-            key: api-key
       - name: GITHUB_TOKEN
         valueFrom:
           secretKeyRef:

--- a/examples/language-operator-team/agent-worker-0.yaml
+++ b/examples/language-operator-team/agent-worker-0.yaml
@@ -42,13 +42,11 @@ spec:
             protocol: TCP
   workspace:
     size: 10Gi
+  claudeCode:
+    apiKeyRef:
+      name: anthropic-credentials
   deployment:
     env:
-      - name: ANTHROPIC_API_KEY
-        valueFrom:
-          secretKeyRef:
-            name: anthropic-credentials
-            key: api-key
       - name: GITHUB_TOKEN
         valueFrom:
           secretKeyRef:

--- a/examples/language-operator-team/agent-worker-1.yaml
+++ b/examples/language-operator-team/agent-worker-1.yaml
@@ -42,13 +42,11 @@ spec:
             protocol: TCP
   workspace:
     size: 10Gi
+  claudeCode:
+    apiKeyRef:
+      name: anthropic-credentials
   deployment:
     env:
-      - name: ANTHROPIC_API_KEY
-        valueFrom:
-          secretKeyRef:
-            name: anthropic-credentials
-            key: api-key
       - name: GITHUB_TOKEN
         valueFrom:
           secretKeyRef:

--- a/examples/language-operator-team/agent-worker-2.yaml
+++ b/examples/language-operator-team/agent-worker-2.yaml
@@ -42,13 +42,11 @@ spec:
             protocol: TCP
   workspace:
     size: 10Gi
+  claudeCode:
+    apiKeyRef:
+      name: anthropic-credentials
   deployment:
     env:
-      - name: ANTHROPIC_API_KEY
-        valueFrom:
-          secretKeyRef:
-            name: anthropic-credentials
-            key: api-key
       - name: GITHUB_TOKEN
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
## Summary

- Replaces the verbose `spec.deployment.env[ANTHROPIC_API_KEY].valueFrom.secretKeyRef` pattern in all four example agent YAMLs with the concise `spec.claudeCode.apiKeyRef.name` field introduced in #848
- Workers and supervisor now read the Anthropic API key via the operator's managed injection path rather than wiring it manually

Closes #847