### PR TITLE
fix: inject full /mcp URL for tool endpoints so MCP clients connect directly

### DIFF
--- a/examples/development-team/README.md
+++ b/examples/development-team/README.md
@@ -11,6 +11,10 @@ worker-1 (engineer persona)  ← queue/1: normal (features, improvements)
 worker-2 (engineer persona)  ← queue/2: backlog (chores, docs, cleanup)
 ```
 
+The three workers reference the [`context7`](../tools/context7/) `LanguageTool`, giving them
+up-to-date, version-specific library documentation over MCP so they stop coding against stale or
+hallucinated APIs.
+
 ## Prerequisites
 
 - Language Operator [installed](https://langop.io/docs/getting-started/installation/)
@@ -31,6 +35,7 @@ worker-2 (engineer persona)  ← queue/2: backlog (chores, docs, cleanup)
 | `PROJECT_NAME` | no | basename of `PROJECT_REPOSITORY` | Human-readable project name used in agent prompts (e.g. `Language Operator`) |
 | `ANTHROPIC_API_KEY` | no | — | If set, written to `anthropic-credentials/api-key` and injected as `ANTHROPIC_API_KEY` on every agent (API-key billing). |
 | `CLAUDE_CODE_OAUTH_TOKEN` | no | — | Long-lived subscription token from `claude setup-token`. Written to `claude-code-oauth/token` and injected as `CLAUDE_CODE_OAUTH_TOKEN` (subscription billing, headless — no `/login` needed). |
+| `CONTEXT7_API_KEY` | no | — | [Context7 API key](https://context7.com/dashboard) for higher rate limits. Written to `context7-mcp-credentials/api-key`. The `context7` tool works without it at a lower rate limit. |
 
 If neither `ANTHROPIC_API_KEY` nor `CLAUDE_CODE_OAUTH_TOKEN` is set, agents authenticate interactively via `/login` in each terminal.
 
@@ -72,12 +77,14 @@ kubectl port-forward -n my-cluster svc/worker-0 8080:8080
 - `Secret/github-credentials` — GitHub PAT
 - `Secret/anthropic-credentials` — Anthropic API key (only if `ANTHROPIC_API_KEY` was set)
 - `Secret/claude-code-oauth` — Claude Code OAuth token (only if `CLAUDE_CODE_OAUTH_TOKEN` was set)
+- `Secret/context7-mcp-credentials` — Context7 API key (only if `CONTEXT7_API_KEY` was set)
 - `LanguagePersona/project-manager` — supervisor behavioral config
 - `LanguagePersona/engineer` — worker behavioral config
+- `LanguageTool/context7` — Context7 MCP tool referenced by the workers; the operator generates its `Deployment` and `Service`
 - `LanguageAgent/supervisor` — triages issues; 5Gi workspace
-- `LanguageAgent/worker-0` — queue/0 (urgent); 10Gi workspace
-- `LanguageAgent/worker-1` — queue/1 (normal); 10Gi workspace
-- `LanguageAgent/worker-2` — queue/2 (backlog); 10Gi workspace
+- `LanguageAgent/worker-0` — queue/0 (urgent); 10Gi workspace; uses `context7`
+- `LanguageAgent/worker-1` — queue/1 (normal); 10Gi workspace; uses `context7`
+- `LanguageAgent/worker-2` — queue/2 (backlog); 10Gi workspace; uses `context7`
 
 Each `LanguageAgent` also produces a `Deployment`, `Service`, `NetworkPolicy`, `PersistentVolumeClaim`, and `ConfigMap`.
 
@@ -107,5 +114,5 @@ Type a prompt in the terminal to trigger a delegation pass. Use the same pattern
 
 ```bash
 kubectl delete -k examples/development-team/ -n my-cluster
-kubectl delete secret github-credentials anthropic-credentials claude-code-oauth -n my-cluster --ignore-not-found
+kubectl delete secret github-credentials anthropic-credentials claude-code-oauth context7-mcp-credentials -n my-cluster --ignore-not-found
 ```

--- a/examples/development-team/install.sh
+++ b/examples/development-team/install.sh
@@ -45,4 +45,13 @@ if [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
         --dry-run=client -o yaml | kubectl apply -f -
 fi
 
+# Context7 API key is optional — the tool works without it at a lower rate limit
+# and references the secret with optional:true, so the pod starts either way.
+if [[ -n "${CONTEXT7_API_KEY:-}" ]]; then
+    kubectl create secret generic context7-mcp-credentials \
+        --from-literal=api-key="$CONTEXT7_API_KEY" \
+        --namespace "$CLUSTER_NAME" \
+        --dry-run=client -o yaml | kubectl apply -f -
+fi
+
 kubectl kustomize "$TMPDIR" | kubectl apply -f -

--- a/examples/development-team/kustomization.yaml
+++ b/examples/development-team/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - languagepersona.project-manager.yaml
   - languagepersona.engineer.yaml
+  - languagetool.context7.yaml
   - languageagent.supervisor.yaml
   - languageagent.worker-0.yaml
   - languageagent.worker-1.yaml

--- a/examples/development-team/languageagent.worker-0.yaml
+++ b/examples/development-team/languageagent.worker-0.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   runtime: claude-code
   persona: engineer
+  tools:
+    - name: context7
   instructions: |
     You are worker-0 for the ${PROJECT_NAME} engineering team, responsible for
     queue/0 (urgent work). Your job is to continuously pick up issues from
@@ -52,7 +54,9 @@ spec:
 
     13. Loop: go back to step 1 until queue/0 is empty.
 
-    Use `gh` for all GitHub operations.
+    Use `gh` for all GitHub operations. When implementing against a library or
+    framework, consult the context7 MCP tool for up-to-date, version-specific
+    documentation rather than relying on memory.
   networkPolicies:
     egress:
       - to:

--- a/examples/development-team/languageagent.worker-1.yaml
+++ b/examples/development-team/languageagent.worker-1.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   runtime: claude-code
   persona: engineer
+  tools:
+    - name: context7
   instructions: |
     You are worker-1 for the ${PROJECT_NAME} engineering team, responsible for
     queue/1 (normal work). Your job is to continuously pick up issues from
@@ -52,7 +54,9 @@ spec:
 
     13. Loop: go back to step 1 until queue/1 is empty.
 
-    Use `gh` for all GitHub operations.
+    Use `gh` for all GitHub operations. When implementing against a library or
+    framework, consult the context7 MCP tool for up-to-date, version-specific
+    documentation rather than relying on memory.
   networkPolicies:
     egress:
       - to:

--- a/examples/development-team/languageagent.worker-2.yaml
+++ b/examples/development-team/languageagent.worker-2.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   runtime: claude-code
   persona: engineer
+  tools:
+    - name: context7
   instructions: |
     You are worker-2 for the ${PROJECT_NAME} engineering team, responsible for
     queue/2 (backlog). Your job is to continuously pick up issues from queue/2,
@@ -52,7 +54,9 @@ spec:
 
     13. Loop: go back to step 1 until queue/2 is empty.
 
-    Use `gh` for all GitHub operations.
+    Use `gh` for all GitHub operations. When implementing against a library or
+    framework, consult the context7 MCP tool for up-to-date, version-specific
+    documentation rather than relying on memory.
   networkPolicies:
     egress:
       - to:

--- a/examples/development-team/languagetool.context7.yaml
+++ b/examples/development-team/languagetool.context7.yaml
@@ -1,0 +1,37 @@
+apiVersion: langop.io/v1alpha1
+kind: LanguageTool
+metadata:
+  name: context7
+  namespace: ${CLUSTER_NAME}
+spec:
+  # Context7 ships as a stdio MCP server. transport=stdio tells the operator to run it under a
+  # pinned, persistent stdio→Streamable-HTTP bridge (one long-lived child) and serve /mcp on
+  # spec.port. No supergateway flags, npm-cache volume, or HOME env are needed here — the
+  # operator injects the bridge, a writable cache + /tmp, and the readiness probe.
+  transport: stdio
+  port: 8080
+  stdio:
+    command:
+      - npx
+      - -y
+      - "@upstash/context7-mcp"
+  deployment:
+    env:
+      # The API key is optional: without it Context7 still works, just at a lower rate limit.
+      # optional:true lets the pod start when the secret is absent (install without an API key).
+      - name: CONTEXT7_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: context7-mcp-credentials
+            key: api-key
+            optional: true
+  # The operator's default tool policy denies external egress. Context7 needs public HTTPS
+  # twice over: npx fetches the server package from the npm registry at boot, and the server
+  # calls Context7's API at runtime. Without this the pod can't start.
+  networkPolicies:
+    egress:
+      - to:
+          - cidr: "0.0.0.0/0"
+        ports:
+          - port: 443
+            protocol: TCP

--- a/spec/agents.md
+++ b/spec/agents.md
@@ -62,7 +62,7 @@ The operator injects the following environment variables into every agent contai
 | `AGENT_CLUSTER_UUID` | Kubernetes UID of the LanguageCluster |
 | `MODEL_ENDPOINT` | Single shared LiteLLM gateway URL (`http://gateway.<namespace>.svc.cluster.local:8000`). The same URL is used regardless of how many models are referenced. |
 | `LLM_MODEL` | Comma-separated list of model names for all referenced models |
-| `MCP_SERVERS` | Comma-separated MCP tool server URLs for all resolved tools — service-mode tools use `http://<name>.<ns>.svc.cluster.local:<port>`; sidecar-mode tools use `http://localhost:<port>`. The runtime speaks Streamable HTTP MCP to `<url>/mcp` regardless of the tool's `spec.transport` (stdio tools are bridged to Streamable HTTP by the operator). Only injected when at least one tool is resolved. |
+| `MCP_SERVERS` | Comma-separated full MCP tool URLs (each already includes the `/mcp` path) for all resolved tools — service-mode tools use `http://<name>.<ns>.svc.cluster.local:<port>/mcp`; sidecar-mode tools use `http://localhost:<port>/mcp`. The runtime connects to each URL directly as a Streamable HTTP MCP server (stdio tools are bridged to Streamable HTTP by the operator). Only injected when at least one tool is resolved. |
 | `AGENT_INSTRUCTIONS` | Content of `spec.instructions`; only set when instructions are non-empty. Identical to the `instructions` field in `/etc/agent/config.yaml`. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Propagated from the operator environment when configured; enables agent-side OTEL tracing |
 | `OTEL_SERVICE_NAME` | Set to `agent-<name>` when `OTEL_EXPORTER_OTLP_ENDPOINT` is configured |
@@ -126,13 +126,13 @@ personas:
     personality: Analytical and precise, always cites data sources and uses structured output
     expertise: Data analysis, statistical reasoning, and visualization
 
-# Tool endpoints — keyed by tool name, resolved to in-cluster MCP service URLs.
+# Tool endpoints — keyed by tool name, resolved to full in-cluster MCP URLs (incl. /mcp).
 tools:
   mem0-memory:
-    endpoint: http://mem0-memory.tools.svc.cluster.local:8080
+    endpoint: http://mem0-memory.tools.svc.cluster.local:8080/mcp
     protocol: mcp
   python-executor:
-    endpoint: http://python-executor.tools.svc.cluster.local:8080
+    endpoint: http://python-executor.tools.svc.cluster.local:8080/mcp
     protocol: mcp
 
 # Model configuration — keyed by model name.

--- a/spec/tools.md
+++ b/spec/tools.md
@@ -29,7 +29,8 @@ can run under the hardened, read-only-root pod securityContext. You don't manage
 ## What the operator provides
 
 1. Creates and manages the tool's Deployment and Service (for `deploymentMode: service`).
-2. Resolves the endpoint: `http://<service-name>.<namespace>.svc.cluster.local:<port>`.
+2. Resolves the tool's MCP endpoint — the full Streamable HTTP URL including the `/mcp` path:
+   `http://<service-name>.<namespace>.svc.cluster.local:<port>/mcp`.
 3. Discovers the tool's schema by performing an MCP handshake against `/mcp` (see below) and
    records it in `status.toolSchemas`.
 4. Injects the resolved endpoint into each referencing agent via `MCP_SERVERS` and the `tools:`
@@ -134,19 +135,20 @@ spec:
 
 The operator injects tool endpoints into each referencing agent two ways:
 
-1. **`MCP_SERVERS` env var** — a comma-separated list of tool endpoint URLs (e.g.
-   `http://mem0-memory.language-operator-myapp.svc.cluster.local:8080`)
+1. **`MCP_SERVERS` env var** — a comma-separated list of full tool MCP URLs (e.g.
+   `http://mem0-memory.language-operator-myapp.svc.cluster.local:8080/mcp`)
 2. **`/etc/agent/config.yaml`** — a `tools:` map keyed by tool name:
 
 ```yaml
 tools:
   mem0-memory:
-    endpoint: http://mem0-memory.language-operator-myapp.svc.cluster.local:8080
+    endpoint: http://mem0-memory.language-operator-myapp.svc.cluster.local:8080/mcp
     protocol: mcp
 ```
 
-The endpoint is identical regardless of transport — agents always speak Streamable HTTP MCP to
-`<endpoint>/mcp`.
+The endpoint is the full Streamable HTTP MCP URL (it already includes `/mcp`) regardless of
+transport — MCP clients connect to it directly, no path-appending required. (The tool's
+`status.endpoint` records the base Service URL without `/mcp`.)
 
 ## Compliance checklist
 

--- a/src/controllers/languageagent_config.go
+++ b/src/controllers/languageagent_config.go
@@ -91,18 +91,11 @@ func (r *LanguageAgentReconciler) reconcileConfigMap(ctx context.Context, agent 
 			l.Error(err, "Failed to get tool for config.yaml, skipping", "tool", toolRef.Name)
 			continue
 		}
-		port := tool.Spec.Port
-		if port == 0 {
-			port = 8080
-		}
-		endpoint := serviceURL(tool.Name, agent.Namespace, port)
-		if tool.Spec.DeploymentMode == "sidecar" {
-			endpoint = fmt.Sprintf("http://localhost:%d", port)
-		}
 		if cfg.Tools == nil {
 			cfg.Tools = make(map[string]toolConfigYAML)
 		}
-		cfg.Tools[tool.Name] = toolConfigYAML{Endpoint: endpoint, Protocol: "mcp"}
+		// Full Streamable HTTP MCP URL (includes /mcp) so MCP clients can use it directly.
+		cfg.Tools[tool.Name] = toolConfigYAML{Endpoint: mcpToolEndpoint(tool, agent.Namespace), Protocol: "mcp"}
 	}
 
 	// Models — all served via the shared namespace gateway

--- a/src/controllers/languageagent_config_test.go
+++ b/src/controllers/languageagent_config_test.go
@@ -204,7 +204,7 @@ func TestLanguageAgentController_ContractEnvVars(t *testing.T) {
 			envMap[e.Name] = e.Value
 		}
 		// Default port is 0 → resolved to 8080 in resolveTools
-		assert.Equal(t, "http://mem0.default.svc.cluster.local:8080", envMap["MCP_SERVERS"])
+		assert.Equal(t, "http://mem0.default.svc.cluster.local:8080/mcp", envMap["MCP_SERVERS"])
 	})
 
 	t.Run("AGENT_INSTRUCTIONS absent when spec.instructions is empty", func(t *testing.T) {
@@ -587,7 +587,7 @@ func TestLanguageAgentController_ConfigMapContent(t *testing.T) {
 
 		require.Contains(t, cfg.Tools, "search-tool", "config.yaml missing tool entry")
 		tool_cfg := cfg.Tools["search-tool"]
-		assert.Equal(t, "http://search-tool.default.svc.cluster.local:8080", tool_cfg.Endpoint)
+		assert.Equal(t, "http://search-tool.default.svc.cluster.local:8080/mcp", tool_cfg.Endpoint)
 		assert.Equal(t, "mcp", tool_cfg.Protocol)
 	})
 
@@ -601,7 +601,7 @@ func TestLanguageAgentController_ConfigMapContent(t *testing.T) {
 		cfg := parseAgentConfigMap(t, scheme, gen.ReadyCluster("default"), tool, agent)
 
 		require.Contains(t, cfg.Tools, "sidecar-tool", "config.yaml missing sidecar tool entry")
-		assert.Equal(t, "http://localhost:8080", cfg.Tools["sidecar-tool"].Endpoint)
+		assert.Equal(t, "http://localhost:8080/mcp", cfg.Tools["sidecar-tool"].Endpoint)
 		assert.Equal(t, "mcp", cfg.Tools["sidecar-tool"].Protocol)
 	})
 

--- a/src/controllers/languageagent_deployment.go
+++ b/src/controllers/languageagent_deployment.go
@@ -349,22 +349,8 @@ func (r *LanguageAgentReconciler) resolveTools(ctx context.Context, agent *lango
 			return nil, fmt.Errorf("failed to get tool %s/%s: %w", agent.Namespace, toolRef.Name, err)
 		}
 
-		port := tool.Spec.Port
-		if port == 0 {
-			port = 8080 // Default MCP port
-		}
-
-		// Sidecar tools use localhost URLs
-		if tool.Spec.DeploymentMode == "sidecar" {
-			// Format: http://localhost:<port>
-			localhostURL := fmt.Sprintf("http://localhost:%d", port)
-			toolURLs = append(toolURLs, localhostURL)
-			continue
-		}
-
-		// Build MCP server URL (service mode)
-		mcpURL := serviceURL(tool.Name, agent.Namespace, port)
-		toolURLs = append(toolURLs, mcpURL)
+		// Full Streamable HTTP MCP URL (includes /mcp); sidecar tools resolve to localhost.
+		toolURLs = append(toolURLs, mcpToolEndpoint(tool, agent.Namespace))
 	}
 
 	return toolURLs, nil

--- a/src/controllers/languageagent_deployment_test.go
+++ b/src/controllers/languageagent_deployment_test.go
@@ -354,7 +354,7 @@ func TestLanguageAgentController_ResolveTools(t *testing.T) {
 		if len(urls) != 1 {
 			t.Fatalf("expected 1 URL, got %d", len(urls))
 		}
-		expected := "http://my-tool.default.svc.cluster.local:8080"
+		expected := "http://my-tool.default.svc.cluster.local:8080/mcp"
 		if urls[0] != expected {
 			t.Errorf("expected %q, got %q", expected, urls[0])
 		}
@@ -383,7 +383,7 @@ func TestLanguageAgentController_ResolveTools(t *testing.T) {
 		if len(urls) != 1 {
 			t.Fatalf("expected 1 URL, got %d", len(urls))
 		}
-		expected := "http://localhost:9090"
+		expected := "http://localhost:9090/mcp"
 		if urls[0] != expected {
 			t.Errorf("expected %q, got %q", expected, urls[0])
 		}
@@ -426,7 +426,7 @@ func TestLanguageAgentController_ResolveTools(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		expected := "http://port-tool.default.svc.cluster.local:9999"
+		expected := "http://port-tool.default.svc.cluster.local:9999/mcp"
 		if len(urls) != 1 || urls[0] != expected {
 			t.Errorf("expected %q, got %v", expected, urls)
 		}

--- a/src/controllers/utils_network.go
+++ b/src/controllers/utils_network.go
@@ -426,6 +426,20 @@ func serviceURL(name, namespace string, port int32) string {
 	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", name, namespace, port)
 }
 
+// mcpToolEndpoint returns the Streamable HTTP MCP URL an agent uses to reach a tool, including
+// the /mcp path so the value is directly usable by an MCP client (no path-appending required).
+// Sidecar-mode tools are reached over localhost; service-mode tools via the in-cluster Service.
+func mcpToolEndpoint(tool *langopv1alpha1.LanguageTool, namespace string) string {
+	port := tool.Spec.Port
+	if port == 0 {
+		port = 8080 // Default MCP port
+	}
+	if tool.Spec.DeploymentMode == "sidecar" {
+		return fmt.Sprintf("http://localhost:%d/mcp", port)
+	}
+	return serviceURL(tool.Name, namespace, port) + "/mcp"
+}
+
 // buildNetworkPolicyIngressRules converts user-defined ingress policies into
 // networkingv1.NetworkPolicyIngressRule slices, normalising missing protocol
 // values to TCP.


### PR DESCRIPTION
## Summary

Agents received the **base** tool URL (`http://<tool>.<ns>.svc.cluster.local:<port>`) in `config.yaml` and `MCP_SERVERS`, with the consumer implicitly expected to append `/mcp`. claude-code's HTTP MCP transport uses the configured URL **verbatim**, so it hit the bridge's base path → **404** → `claude mcp list` reported `✗ Failed to connect`.

This injects the **full Streamable HTTP MCP URL (including `/mcp`)** so any MCP client can use it directly, via a shared `mcpToolEndpoint` helper covering both service-mode (Service URL) and sidecar-mode (`localhost`) tools. The tool's `status.endpoint` stays the base Service URL.

## Diagnosis (on a live cluster)

```
GET  /health        → 200   (network + service fine)
POST /mcp initialize→ 200   (bridge fine)
GET  /              → 404   ← what claude-code hit (base URL, no /mcp)

context7   http://…:8080      (HTTP)  ✗ Failed to connect
ctx7test   http://…:8080/mcp  (HTTP)  ✓ Connected
```

## Verification

Redeployed the operator → the agent auto-rolled (config-hash change) → `MCP_SERVERS=http://context7.my-cluster.svc.cluster.local:8080/mcp` → `claude mcp list` → **context7 ✓ Connected**. `make test` green.

## Notes / follow-ups

- `spec/tools.md` and `spec/agents.md` updated to document that the advertised endpoint already includes `/mcp`.
- The operator now provides the full `/mcp` URL, so runtime adapters should pass it **verbatim**. If the opencode/openclaw adapters currently append `/mcp` themselves, they'll now double up (`/mcp/mcp`) — worth checking / filing issues in those repos. claude-code already passes it verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)