### PR TITLE
docs: remove non-existent agent execution mode and AGENT_MODE references

### DIFF
--- a/docs/api/languageagent.md
+++ b/docs/api/languageagent.md
@@ -87,13 +87,6 @@ Entries declared by the agent's runtime are merged first, then the agent's own e
 
 Agents cannot configure authentication directly. Whether an agent sits behind the cluster's OIDC proxy is determined by its runtime's `auth.enabled` setting combined with the cluster's `auth.enabled` setting. See [LanguageAgentRuntime](languageagentruntime.md#authentication) and [Clusters](../components/clusters.md#authentication) for the effective model.
 
-### Execution Modes
-
-- `autonomous` - Continuously running agent
-- `scheduled` - Cron-based execution
-- `interactive` - User-triggered execution
-- `event-driven` - Responds to Kubernetes events
-
 ### Model References
 
 Each entry in `spec.models` is a `ModelReference` with the following fields:

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -33,13 +33,12 @@ A `LanguageCluster` creates an isolated environment for agents, models, and tool
 ### LanguageAgent
 
 **Scope:** Namespace
-**Purpose:** Autonomous, scheduled, and reactive agents
+**Purpose:** AI agents running as Kubernetes workloads
 
 A `LanguageAgent` represents an AI agent running as a Kubernetes workload with:
 
 - Container image specification
 - Model, tool, and persona references
-- Execution mode (autonomous, scheduled, interactive)
 - Configuration injection
 - Workspace storage
 

--- a/spec/agents.md
+++ b/spec/agents.md
@@ -238,6 +238,6 @@ A well-behaved agent image should:
 
 - [ ] Listen on the port(s) defined in `spec.ports` (default: one port named `http` on `8080`)
 - [ ] Read runtime configuration from `/etc/agent/config.yaml` on startup (if present); task instructions are in the top-level `instructions` field
-- [ ] Respect `AGENT_NAME`, `AGENT_NAMESPACE`, `AGENT_UUID`, `AGENT_MODE`, `AGENT_CLUSTER_NAME`, `AGENT_CLUSTER_UUID` environment variables
+- [ ] Respect `AGENT_NAME`, `AGENT_NAMESPACE`, `AGENT_UUID`, `AGENT_CLUSTER_NAME`, `AGENT_CLUSTER_UUID` environment variables
 - [ ] Route LLM traffic through `MODEL_ENDPOINT` proxy URLs rather than connecting to model APIs directly
 - [ ] Use `spec.workspace.mountPath` (default `/workspace`) for persistent state — do not assume local container storage survives restarts


### PR DESCRIPTION
Closes #859

Removes documentation describing a LanguageAgent "execution mode" (autonomous/scheduled/interactive/event-driven) and an `AGENT_MODE` env var — neither exists in the operator. `LanguageAgentSpec` has no `mode` field and `buildAgentEnv` never injects `AGENT_MODE`.

- `docs/api/languageagent.md`: delete the "Execution Modes" section
- `docs/api/overview.md`: fix the purpose line, drop the "Execution mode" bullet
- `spec/agents.md`: remove `AGENT_MODE` from the compliance checklist

`make docs-build` (strict mkdocs) passes.