### PR TITLE
docs: add claude-code to bundled-runtimes table and fix disable-runtime key

### DIFF
--- a/docs/api/languageagentruntime.md
+++ b/docs/api/languageagentruntime.md
@@ -21,13 +21,13 @@ The standard runtimes are installed automatically with the Helm chart:
 |------|-------|------|----------|
 | `openclaw` | `ghcr.io/openclaw/openclaw:latest` | 18789 | AI personal assistant (WebSocket gateway) |
 | `opencode` | `ghcr.io/anomalyco/opencode:latest` | 3000 | AI coding assistant (HTTP/browser UI) |
+| `claude-code` | `ghcr.io/language-operator/claude-code-adapter:latest` | 8080 | AI coding assistant (HTTP/WebSocket terminal) |
 
 Disable a bundled runtime in `values.yaml`:
 
 ```yaml
-runtimes:
-  opencode:
-    enabled: false
+opencode:
+  enabled: false
 ```
 
 ## Custom Runtimes


### PR DESCRIPTION
Closes #863

## Summary
- Add `claude-code` (`ghcr.io/language-operator/claude-code-adapter:latest`, port 8080) to the bundled-runtimes table in `docs/api/languageagentruntime.md`
- Fix the disable-runtime example from the non-existent nested `runtimes:` key to the correct top-level `opencode.enabled: false` structure, matching `charts/language-operator-runtimes/values.yaml` and `docs/components/runtimes.md`