### PR TITLE
docs: fix LanguageCluster OIDC example and add spec.auth API reference

### DIFF
--- a/docs/api/languagecluster.md
+++ b/docs/api/languagecluster.md
@@ -223,6 +223,52 @@ spec:
       enabled: false
 ```
 
+### Authentication
+
+Use `spec.auth` to enable OIDC authentication for the cluster. See [Authentication](../components/clusters.md#authentication) in the clusters guide for full usage examples.
+
+**`spec.auth` fields (`ClusterAuthSpec`):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `enabled` | bool | Enable OIDC authentication for the cluster (default: false) |
+| `oidc` | *ClusterOIDCSpec | OIDC provider configuration (embedded Dex or external) |
+
+**`spec.auth.oidc` fields (`ClusterOIDCSpec`):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `dex` | *DexSpec | Embedded Dex configuration. When set, the operator deploys Dex alongside the gateway. Mutually exclusive with `externalIssuerURL`. |
+| `externalIssuerURL` | string | Skip deploying Dex and use this issuer URL directly (e.g. `"https://accounts.google.com"`). Mutually exclusive with `dex`. |
+| `clientID` | string | OAuth2 client ID. Only used with `externalIssuerURL`; ignored when `dex` is set (the operator manages the client ID). |
+| `clientSecretRef` | *SecretReference | Reference to a Secret containing the OAuth2 client secret. Only used with `externalIssuerURL`; ignored when `dex` is set. |
+| `emailDomain` | string | Restrict logins to this email domain. Set to `"*"` to allow all domains (default). |
+
+**`spec.auth.oidc.dex` fields (`DexSpec`):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `connectors` | []DexConnector | Upstream identity provider connectors (GitHub, Google, OIDC, LDAP, etc.) |
+| `enablePasswordDB` | bool | Enable Dex's built-in local password store (default: false) |
+| `staticPasswords` | []DexStaticPassword | Local user accounts for the built-in password store. Only used when `enablePasswordDB` is true. |
+| `image` | string | Override the Dex container image. Defaults to the operator Helm chart's `config.auth.dex.image`. |
+
+**`spec.auth.oidc.dex.connectors[]` fields (`DexConnector`):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | string | Connector type: `"github"`, `"google"`, `"oidc"`, `"ldap"`, `"microsoft"`, `"saml"`, etc. See [Dex connector docs](https://dexidp.io/docs/connectors/). |
+| `id` | string | Unique identifier for this connector |
+| `name` | string | Human-readable display name shown on the Dex login page |
+| `config` | map[string]string | Connector-specific configuration key/value pairs |
+
+**`spec.auth.oidc.clientSecretRef` fields (`SecretReference`):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Name of the Kubernetes Secret |
+| `key` | string | Key within the Secret containing the client secret value (default: `"api-key"`) |
+
 ### Capacity and Quotas
 
 Use `spec.capacity` to enforce hard resource limits on the cluster's namespace. When set, the operator creates a `ResourceQuota` named `langop-quota` in the namespace. When removed, the quota is deleted.

--- a/docs/components/clusters.md
+++ b/docs/components/clusters.md
@@ -74,19 +74,38 @@ See [LanguageCluster API Reference](../api/languagecluster.md#network-isolation)
 
 ## Authentication
 
-`LanguageCluster.spec.auth` is the cluster-wide authentication switch. Setting `auth.enabled: true` provisions the OIDC infrastructure (Dex) for the namespace, and `auth.oidc.*` holds the connection config — issuer, Dex connectors, client ID, and email domain:
+`LanguageCluster.spec.auth` is the cluster-wide authentication switch. Setting `auth.enabled: true` provisions OIDC authentication for the namespace. There are two mutually exclusive paths under `auth.oidc`:
+
+**Embedded Dex** — the operator deploys a Dex instance alongside the gateway. Connectors go under `oidc.dex.connectors`:
 
 ```yaml
 spec:
   auth:
     enabled: true
     oidc:
-      issuer: https://dex.agents.example.com
-      clientID: language-operator
       emailDomain: example.com
-      connectors:
-        - type: github
-          # ...connector config
+      dex:
+        connectors:
+          - type: github
+            id: github
+            name: GitHub
+            config:
+              clientID: my-github-app-client-id
+              clientSecret: my-github-app-client-secret
+```
+
+**External OIDC provider** — skip Dex and point at an existing issuer directly. Use `oidc.externalIssuerURL` together with `clientID` and `clientSecretRef`:
+
+```yaml
+spec:
+  auth:
+    enabled: true
+    oidc:
+      externalIssuerURL: https://accounts.google.com
+      clientID: language-operator
+      clientSecretRef:
+        name: oidc-client-secret
+      emailDomain: example.com
 ```
 
 Enabling auth on the cluster does not, by itself, put any agent behind the proxy. An agent is placed behind the OIDC proxy **only when both** the cluster has `auth.enabled: true` **and** the agent's runtime has `auth.enabled: true`. An agent with no runtime, or whose runtime does not enable auth, is never proxied — there is no per-agent auth override.


### PR DESCRIPTION
## Summary

- Corrects the `clusters.md` authentication example which used non-existent fields (`oidc.issuer`, `oidc.connectors`) and mixed the embedded-Dex and external-OIDC paths into a single invalid example
- Replaces with two valid, distinct examples: embedded Dex (connectors under `oidc.dex.connectors`) and external OIDC (`externalIssuerURL` + `clientID` + `clientSecretRef`)
- Adds a complete `spec.auth` field reference section to `languagecluster.md`, which previously omitted `ClusterAuthSpec`, `ClusterOIDCSpec`, `DexSpec`, and `DexConnector` entirely

## Test plan

- [ ] Review corrected OIDC example matches `ClusterOIDCSpec` fields in `src/api/v1alpha1/languagecluster_types.go`
- [ ] Verify embedded-Dex path uses `oidc.dex.connectors` (not `oidc.connectors`)
- [ ] Verify external-OIDC path uses `oidc.externalIssuerURL` (not `oidc.issuer`)
- [ ] Confirm new API reference tables cover all fields from `ClusterAuthSpec`, `ClusterOIDCSpec`, `DexSpec`, `DexConnector`, and `SecretReference`

Closes #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)