### PR TITLE
docs: fix persona field list and add Degraded phase to LanguageTool status table

### DIFF
--- a/docs/api/languagetool.md
+++ b/docs/api/languagetool.md
@@ -178,6 +178,7 @@ spec:
 | `Running` | Deployment is available and the tool is healthy |
 | `Updating` | A spec change is in progress (e.g. image update or replica change); not yet fully rolled out |
 | `Failed` | Deployment failed or health check is not passing |
+| `Degraded` | Deployment is running but a non-critical subsystem (e.g. NetworkPolicy) has failed; tool is operational at reduced capability |
 
 ## Tool Discovery
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ The operator creates the Deployment, Service, and NetworkPolicy, injects model e
 | `LanguageAgentRuntime` | Reusable defaults for a class of agents |
 | `LanguageModel` | An LLM endpoint, proxied through LiteLLM |
 | `LanguageTool` | An MCP-compatible tool server |
-| `LanguagePersona` | Reusable behavioral configuration — tone, expertise, constraints |
+| `LanguagePersona` | Reusable behavioral configuration — tone, personality, expertise |
 
 ## Project Status
 


### PR DESCRIPTION
Closes #867

Two accuracy fixes:

1. **`docs/index.md`**: `LanguagePersona` description listed `constraints` (no such field). Corrected to `tone, personality, expertise` matching `LanguagePersonaSpec`.

2. **`docs/api/languagetool.md`**: Status phase table was missing `Degraded`. Added row with description matching the controller logic (running but a non-critical subsystem like NetworkPolicy failed).