### PR TITLE
docs: document LanguageAgentSelfConfig CRD and spec.selfConfigure

### DIFF
--- a/docs/api/languageagent.md
+++ b/docs/api/languageagent.md
@@ -87,6 +87,28 @@ Entries declared by the agent's runtime are merged first, then the agent's own e
 
 Agents cannot configure authentication directly. Whether an agent sits behind the cluster's OIDC proxy is determined by its runtime's `auth.enabled` setting combined with the cluster's `auth.enabled` setting. See [LanguageAgentRuntime](languageagentruntime.md#authentication) and [Clusters](../components/clusters.md#authentication) for the effective model.
 
+### Self-Configuration
+
+`spec.selfConfigure` controls whether the agent pod may submit [`LanguageAgentSelfConfig`](languageagentselfconfig.md) requests to modify its own spec at runtime. When enabled, the operator grants the agent's ServiceAccount permission to create `LanguageAgentSelfConfig` resources in the same namespace.
+
+```yaml
+spec:
+  selfConfigure:
+    enabled: true
+    allowedActions:
+      - tools
+      - envVars
+```
+
+**`spec.selfConfigure` fields (`SelfConfigureSpec`):**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | *bool | `false` | Gate for all self-configuration. When `false`, any `LanguageAgentSelfConfig` targeting this agent is immediately denied. |
+| `allowedActions` | []string | `[]` | Allowlist of self-config categories. When `enabled` is `true` but this list is empty, all actions are denied. Valid values: `tools`, `models`, `envVars`, `instructions`, `roleRules`. |
+
+See [LanguageAgentSelfConfig](languageagentselfconfig.md) for the full self-config request API.
+
 ### Model References
 
 Each entry in `spec.models` is a `ModelReference` with the following fields:
@@ -216,5 +238,6 @@ Agents are deployed as standard Kubernetes Deployments with:
 - [LanguageModel](languagemodel.md) - Configure LLM access
 - [LanguageTool](languagetool.md) - Add tool capabilities
 - [LanguagePersona](languagepersona.md) - Define behavioral templates
+- [LanguageAgentSelfConfig](languageagentselfconfig.md) - Runtime self-modification requests
 - [Agent Runtime Contract](../components/agents.md) - What the operator injects
 

--- a/docs/api/languageagentselfconfig.md
+++ b/docs/api/languageagentselfconfig.md
@@ -1,0 +1,90 @@
+# LanguageAgentSelfConfig
+
+The `LanguageAgentSelfConfig` CRD (`lasc`) allows an agent pod to request runtime modifications to its own `LanguageAgent` spec. The operator validates each request against the parent agent's `spec.selfConfigure` allowlist before applying the patch.
+
+## Overview
+
+Self-config requests are short-lived, namespace-scoped resources. The controller processes them once and transitions them to a terminal phase (`Applied`, `Denied`, or `Failed`). Completed requests are automatically deleted one hour after reaching a terminal phase.
+
+## Quick Example
+
+```yaml
+apiVersion: langop.io/v1alpha1
+kind: LanguageAgentSelfConfig
+metadata:
+  name: add-web-search
+  namespace: my-agents
+spec:
+  instanceRef: my-agent
+  addTools:
+    - web-search
+```
+
+The parent agent must have `spec.selfConfigure.enabled: true` and `tools` in `spec.selfConfigure.allowedActions` for this request to be applied.
+
+## Complete API Reference
+
+### `spec` fields (`LanguageAgentSelfConfigSpec`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `instanceRef` | string | Name of the `LanguageAgent` to modify. Must be in the same namespace. **Required.** |
+| `addTools` | []string | `LanguageTool` names to append to `spec.tools` on the parent agent. Requires `tools` in `allowedActions`. |
+| `removeTools` | []string | `LanguageTool` names to remove from `spec.tools` on the parent agent. Requires `tools` in `allowedActions`. |
+| `addModels` | []string | `LanguageModel` names to append to `spec.models` on the parent agent. Requires `models` in `allowedActions`. |
+| `removeModels` | []string | `LanguageModel` names to remove from `spec.models` on the parent agent. Requires `models` in `allowedActions`. |
+| `addEnvVars` | []SelfConfigEnvVar | Plain-value environment variables to inject into `spec.deployment.env`. Existing variables with the same name are overwritten. SecretKeyRef and other value sources are not supported. Requires `envVars` in `allowedActions`. |
+| `updateInstructions` | string | When non-empty, replaces `spec.instructions` on the parent agent. Requires `instructions` in `allowedActions`. |
+| `addRoleRules` | []PolicyRule | RBAC policy rules to append to `spec.deployment.roleRules`. Duplicate rules are de-duplicated. Requires `roleRules` in `allowedActions`. |
+
+### `spec.addEnvVars[]` fields (`SelfConfigEnvVar`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Environment variable name. **Required.** |
+| `value` | string | Literal string value. **Required.** |
+
+### `status` fields (`LanguageAgentSelfConfigStatus`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `phase` | string | Current processing state: `Pending`, `Applied`, `Failed`, or `Denied`. |
+| `message` | string | Human-readable explanation of the current phase. |
+| `completionTime` | time | Set when the request reaches a terminal phase. The CR is deleted 1 hour after this time. |
+
+## Phase Lifecycle
+
+```
+Pending → Applied   (changes patched onto parent LanguageAgent)
+        → Denied    (selfConfigure not enabled, or action not in allowedActions)
+        → Failed    (controller error while processing the request)
+```
+
+## Enabling Self-Configuration
+
+The parent agent must opt in via `spec.selfConfigure`:
+
+```yaml
+apiVersion: langop.io/v1alpha1
+kind: LanguageAgent
+metadata:
+  name: my-agent
+spec:
+  selfConfigure:
+    enabled: true
+    allowedActions:
+      - tools      # addTools / removeTools
+      - models     # addModels / removeModels
+      - envVars    # addEnvVars
+      - instructions  # updateInstructions
+      - roleRules  # addRoleRules
+```
+
+When `enabled` is `true`, the operator grants the agent's ServiceAccount permission to create `LanguageAgentSelfConfig` resources in the namespace.
+
+When `allowedActions` is empty (while `enabled: true`), all requests are immediately denied.
+
+## Related Resources
+
+- [LanguageAgent](languageagent.md) — parent resource; `spec.selfConfigure` controls the gate
+- [CRD Overview](overview.md) — all Language Operator CRDs

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -1,6 +1,6 @@
 # CRD Reference Overview
 
-Language Operator provides five Custom Resource Definitions (CRDs) for managing AI agent workloads on Kubernetes.
+Language Operator provides seven Custom Resource Definitions (CRDs) for managing AI agent workloads on Kubernetes.
 
 !!! tip "Auto-Generated API Reference"
     See the **[Complete API Reference](reference.md)** for auto-generated field documentation from Go types.
@@ -122,6 +122,23 @@ The standard runtimes (`openclaw`, `opencode`) are bundled with the Helm chart a
 
 ---
 
+### LanguageAgentSelfConfig
+
+**Scope:** Namespace
+**Purpose:** Runtime self-modification requests submitted by agent pods
+
+A `LanguageAgentSelfConfig` (`lasc`) is a short-lived, namespace-scoped resource that an agent pod submits to request changes to its own `LanguageAgent` spec at runtime. The controller validates the request against the parent agent's `spec.selfConfigure` allowlist before applying the patch.
+
+**Common Use Cases:**
+
+- Agents dynamically adding tools they discover at runtime
+- Agents injecting new environment variables without a full redeploy
+- Agents updating their own system instructions mid-session
+
+[Full LanguageAgentSelfConfig Reference →](languageagentselfconfig.md)
+
+---
+
 ### LanguagePersona
 
 **Scope:** Namespace
@@ -157,6 +174,7 @@ graph TD
     Model[LanguageModel] -->|deployed in| NS
     Tool[LanguageTool] -->|deployed in| NS
     Persona[LanguagePersona] -->|deployed in| NS
+    SelfConfig[LanguageAgentSelfConfig] -->|deployed in| NS
 
     Agent -->|references| Model
     Agent -->|references| Tool
@@ -166,6 +184,7 @@ graph TD
 
     Agent -->|connects to| Proxy
     Agent -->|connects to| Tool
+    SelfConfig -->|modifies| Agent
 ```
 
 ## Configuration Injection

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -111,6 +111,7 @@ Expected output:
 ```
 languageagentruntimes.langop.io
 languageagents.langop.io
+languageagentselfconfigs.langop.io
 languageclusters.langop.io
 languagemodels.langop.io
 languagepersonas.langop.io
@@ -155,6 +156,7 @@ helm upgrade language-operator-runtimes language-operator/language-operator-runt
     ```bash
     kubectl apply -f https://raw.githubusercontent.com/language-operator/language-operator/main/charts/language-operator/templates/crds/langop.io_languageagents.yaml
     kubectl apply -f https://raw.githubusercontent.com/language-operator/language-operator/main/charts/language-operator/templates/crds/langop.io_languageagentruntimes.yaml
+    kubectl apply -f https://raw.githubusercontent.com/language-operator/language-operator/main/charts/language-operator/templates/crds/langop.io_languageagentselfconfigs.yaml
     kubectl apply -f https://raw.githubusercontent.com/language-operator/language-operator/main/charts/language-operator/templates/crds/langop.io_languageclusters.yaml
     kubectl apply -f https://raw.githubusercontent.com/language-operator/language-operator/main/charts/language-operator/templates/crds/langop.io_languagemodels.yaml
     kubectl apply -f https://raw.githubusercontent.com/language-operator/language-operator/main/charts/language-operator/templates/crds/langop.io_languagepersonas.yaml


### PR DESCRIPTION
## Summary

- Fixes CRD count in `overview.md` from "five" to "seven" and adds a `LanguageAgentSelfConfig` entry with mermaid diagram node
- Adds `languageagentselfconfigs.langop.io` to the CRD verification output and the upgrade `kubectl apply` list in `installation.md`
- Adds a `spec.selfConfigure` field reference section to `languageagent.md` (was completely absent)
- Creates `docs/api/languageagentselfconfig.md` — a new dedicated reference page covering `LanguageAgentSelfConfigSpec`, `SelfConfigEnvVar`, `LanguageAgentSelfConfigStatus`, phase lifecycle, and how to enable self-configuration on the parent agent

## Test plan

- [ ] Verify CRD count is now "seven" in overview.md
- [ ] Confirm `languageagentselfconfigs.langop.io` appears in both the CRD check block and the upgrade apply list
- [ ] Check `spec.selfConfigure` fields in languageagent.md match `SelfConfigureSpec` in `src/api/v1alpha1/languageagentselfconfig_types.go`
- [ ] Verify new languageagentselfconfig.md covers all fields from `LanguageAgentSelfConfigSpec` and `LanguageAgentSelfConfigStatus`
- [ ] Confirm links between languageagent.md and languageagentselfconfig.md are correct

Closes #865

🤖 Generated with [Claude Code](https://claude.com/claude-code)