### PR TITLE
docs: document LanguageTool transport modes and operator-injected stdio bridge

### DIFF
--- a/docs/api/languagetool.md
+++ b/docs/api/languagetool.md
@@ -50,6 +50,62 @@ Tools must implement the Model Context Protocol:
 
 See [Tool Protocol](../components/tools.md) for the full specification.
 
+### Transport
+
+`spec.transport` controls how the operator exposes the tool's MCP endpoint. Three values are supported:
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `streamable-http` | ✓ | `spec.image` already serves Streamable HTTP at `/mcp`. |
+| `sse` | | `spec.image` already serves the legacy MCP HTTP+SSE transport. |
+| `stdio` | | The operator injects a bridge; `spec.image` is ignored. |
+
+#### stdio transport
+
+For `transport: stdio` the operator injects a pinned, persistent bridge (`ghcr.io/language-operator/mcp-bridge:latest`) that runs the user's stdio command as one long-lived child and serves Streamable HTTP at `/mcp` and `/health` on `spec.port`. `spec.image` is ignored — the defaulting webhook fills it automatically.
+
+`spec.stdio.command` is the full argv of the stdio MCP server:
+
+```yaml
+apiVersion: langop.io/v1alpha1
+kind: LanguageTool
+metadata:
+  name: context7
+spec:
+  transport: stdio
+  port: 8080
+  stdio:
+    command:
+      - npx
+      - -y
+      - "@upstash/context7-mcp"
+  networkPolicies:
+    egress:
+      - to:
+          - cidr: "0.0.0.0/0"
+        ports:
+          - port: 443
+            protocol: TCP
+```
+
+The first-party bridge image bundles Node and Python+uv, so both `npx` and `uvx` stdio servers work. Pass environment variables for the stdio process via `spec.deployment.env` or `spec.deployment.envFrom` — they are forwarded to the child.
+
+!!! note "External egress"
+    `npx`/`uvx` fetch their package from the internet on cold boot. Add a `0.0.0.0/0:443` egress rule (as above) so the pod can reach package registries.
+
+##### Customising the bridge image
+
+The bridge image is controlled by Helm values under `config.mcpBridge`:
+
+```yaml
+config:
+  mcpBridge:
+    repository: ghcr.io/language-operator/mcp-bridge  # override to use a different bridge
+    tag: ""          # defaults to the chart appVersion
+    imagePullPolicy: ""
+    discoveryTimeout: "30s"  # increase for servers with slow cold starts
+```
+
 ### Deployment Modes
 
 **Service Mode** (default):
@@ -59,7 +115,7 @@ See [Tool Protocol](../components/tools.md) for the full specification.
 
 **Sidecar Mode**:
 - Tool container injected as a sidecar into each agent pod
-- Endpoint injected as `http://localhost:<port>` (not a Service URL)
+- Endpoint injected as `http://localhost:<port>/mcp` (not a Service URL)
 - Better for stateful or agent-specific tools that need workspace access
 - Shares agent lifecycle
 

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -6,16 +6,43 @@ A `LanguageTool` is an MCP-compatible service that agents call to do things beyo
 
 When you create a `LanguageTool`, the operator:
 
-1. Deploys the tool image as a standard Kubernetes Deployment and Service
-2. Waits for the pod to become ready, then calls `tools/list` to discover what the tool exposes
-3. Stores the discovered schemas in `status.toolSchemas`
-4. Injects the tool's endpoint into every referencing agent via `/etc/agent/config.yaml`
+1. Deploys the tool as a Kubernetes Deployment and Service. For `transport: streamable-http` or `sse` it runs `spec.image` directly; for `transport: stdio` it injects a bridge image that wraps the stdio command and serves Streamable HTTP at `/mcp`.
+2. Waits for the pod to become ready, then calls `tools/list` to discover what the tool exposes.
+3. Stores the discovered schemas in `status.toolSchemas`.
+4. Injects the tool's endpoint (including `/mcp`) into every referencing agent via `/etc/agent/config.yaml`.
 
 Agents connect to tools directly over MCP — the operator doesn't proxy or inspect tool traffic.
 
+## Transports
+
+`spec.transport` selects how the tool's MCP endpoint is exposed:
+
+| Transport | Description |
+|-----------|-------------|
+| `streamable-http` (default) | `spec.image` serves Streamable HTTP at `/mcp` on `spec.port`. |
+| `sse` | `spec.image` serves the legacy MCP HTTP+SSE transport on `spec.port`. |
+| `stdio` | The operator injects a bridge that runs `spec.stdio.command` as a persistent child and serves Streamable HTTP at `/mcp`. `spec.image` is ignored. |
+
+### stdio tools
+
+For `transport: stdio` you provide the full argv of the stdio MCP server in `spec.stdio.command`. The operator injects a pinned bridge (`ghcr.io/language-operator/mcp-bridge:latest`) that bundles Node and Python+uv, so both `npx` and `uvx` commands work without a custom image:
+
+```yaml
+spec:
+  transport: stdio
+  port: 8080
+  stdio:
+    command:
+      - npx
+      - -y
+      - "@upstash/context7-mcp"
+```
+
+The bridge keeps one long-lived child process — there is no per-request spawn. Writable scratch volumes (`HOME` and `/tmp`) are injected automatically so npm/uv caches work even with `readOnlyRootFilesystem`.
+
 ## Deploying a tool
 
-A `LanguageTool` is self-contained. You provide an image; the operator creates the Deployment and Service:
+A `LanguageTool` is self-contained. You provide an image (or a stdio command); the operator creates the Deployment and Service:
 
 ```yaml
 apiVersion: langop.io/v1alpha1
@@ -147,10 +174,12 @@ Runtime adapters (like `openclaw-adapter` and `opencode-adapter`) read this file
 
 ## Checklist
 
-A compliant tool image must:
+For `transport: streamable-http` or `transport: sse`, the tool image must:
 
 - [ ] Implement MCP JSON-RPC at the port defined in `spec.port`
 - [ ] Respond to `tools/list` with all available tools and their input schemas
 - [ ] Respond to `tools/call` with the result of invoking the named tool
 - [ ] Expose `GET /health` returning `200 OK` with `{"status":"ok"}` when ready
 - [ ] Return MCP error objects for failures, not HTTP error status codes
+
+For `transport: stdio`, the operator-injected bridge handles all of the above — the stdio command only needs to speak the [MCP stdio transport](https://spec.modelcontextprotocol.io/specification/2025-11-05/basic/transports/#stdio).

--- a/docs/getting-started/mcp.md
+++ b/docs/getting-started/mcp.md
@@ -155,7 +155,47 @@ Your agent now has access to Kubernetes operations. Ask it to list the pods in y
 
 On pod start, each runtime's adapter init container reads `config.yaml` and writes the tool endpoints into the runtime's native config before the agent starts — no agent code changes required.
 
+## Using a stdio MCP server
+
+Many MCP servers ship as stdio programs (npm packages, Python scripts) rather than HTTP servers. The operator wraps them with a persistent bridge — no custom image required. Set `transport: stdio` and provide the command argv in `spec.stdio.command`:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: langop.io/v1alpha1
+kind: LanguageTool
+metadata:
+  name: context7
+spec:
+  transport: stdio
+  port: 8080
+  stdio:
+    command:
+      - npx
+      - -y
+      - "@upstash/context7-mcp"
+  networkPolicies:
+    egress:
+      - to:
+          - cidr: "0.0.0.0/0"
+        ports:
+          - port: 443
+            protocol: TCP
+EOF
+```
+
+The bridge (`ghcr.io/language-operator/mcp-bridge`) bundles Node and Python+uv, so both `npx` and `uvx` commands work. The egress rule is required because `npx` fetches the package from the npm registry on first boot.
+
+Attach it to an agent the same way as any other tool:
+
+```yaml
+spec:
+  tools:
+    - name: context7
+```
+
+The endpoint injected into `config.yaml` and `MCP_SERVERS` is the same Streamable HTTP URL (`http://context7.<namespace>.svc.cluster.local:8080/mcp`) — agents don't need to know the underlying transport.
+
 ## What's Next?
 
-- [Tools reference](../components/tools.md) — sidecar mode, network policies, and writing your own tool server
+- [Tools reference](../components/tools.md) — transports, sidecar mode, network policies, and writing your own tool server
 - [LanguageTool API reference](../api/languagetool.md) — full spec field documentation


### PR DESCRIPTION
Closes #864

Documents the `spec.transport` / `spec.stdio` fields and the operator-injected stdio→Streamable-HTTP bridge added in #857, across three doc files:

**`docs/api/languagetool.md`** — new "Transport" section under Key Concepts:
- Table of the three transports (`streamable-http`, `sse`, `stdio`)
- `stdio` subsection: bridge injection, `spec.stdio.command`, `spec.image` auto-filled, egress note for npx/uvx cold starts
- Helm `config.mcpBridge` values reference
- Updated sidecar endpoint example to include `/mcp`

**`docs/components/tools.md`** — new "Transports" section and updated "How it works":
- Step 1 updated to mention bridge injection for `stdio` tools
- Transport table and stdio walkthrough with example
- Checklist split: HTTP-transport requirements vs stdio (bridge handles the HTTP side)

**`docs/getting-started/mcp.md`** — new "Using a stdio MCP server" section:
- End-to-end `context7` example using `npx`
- Explains egress requirement, agent attachment, and that the injected URL is identical to HTTP-transport tools