### PR TITLE
docs: document spec.monitoring and advanced spec.workspace fields for LanguageAgent

### DIFF
--- a/docs/api/languageagent.md
+++ b/docs/api/languageagent.md
@@ -224,6 +224,25 @@ Environment variables injected into every agent container and all init container
 
 Additional variables from `spec.deployment.env` and `spec.deployment.envFrom` are passed through unchanged. See [Environment Variables](../components/agents.md#environment-variables) in the architecture docs for the full reference.
 
+### Workspace
+
+When `spec.workspace.enabled` is true (the default), the operator provisions a PersistentVolumeClaim and mounts it into the agent container and all init containers. The PVC is normally deleted when the LanguageAgent is deleted; set `retain: true` to preserve it across agent deletions.
+
+**`spec.workspace` fields (`WorkspaceSpec`):**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | *bool | `true` | Create and mount a workspace PVC. Set to `false` to disable without removing the workspace config. |
+| `size` | string | `10Gi` | PVC storage request (e.g. `"10Gi"`, `"500Mi"`) |
+| `mountPath` | string | `/workspace` | Mount path in the container |
+| `storageClassName` | *string | cluster default | StorageClass for the PVC |
+| `accessMode` | string | `ReadWriteOnce` | PVC access mode: `ReadWriteOnce` or `ReadWriteMany` |
+| `retain` | *bool | `false` | When `true`, the PVC's ownerReference is removed on agent deletion so Kubernetes GC does not collect it. The orphaned PVC name is surfaced in `status.workspacePVCName`. |
+| `initialFiles` | map[string]string | — | Files seeded into the workspace on first boot only. Keys are filenames; values are file contents. Files are not overwritten if they already exist. |
+| `seedConfigMapRef` | *LocalObjectReference | — | External ConfigMap whose keys are filenames and values are file contents. Merged with `initialFiles`; `initialFiles` wins on key collision. |
+
+When `retain` is `true` and the agent is deleted, `status.workspacePVCName` records the name of the orphaned PVC so it can be located and reattached later.
+
 ### Resource Management
 
 Agents are deployed as standard Kubernetes Deployments with:
@@ -232,6 +251,60 @@ Agents are deployed as standard Kubernetes Deployments with:
 - Resource limits and requests (`spec.deployment.resources`)
 - Node selectors, tolerations, and affinity rules
 - Custom liveness, readiness, and startup probes
+
+### Monitoring
+
+`spec.monitoring` integrates the agent with Prometheus Operator. The operator silently skips this if prometheus-operator is not installed.
+
+```yaml
+spec:
+  monitoring:
+    serviceMonitor:
+      enabled: true
+      path: /metrics
+      interval: 30s
+    rules:
+      - name: agent-alerts
+        rules:
+          - alert: AgentDown
+            expr: up{job="my-agent"} == 0
+            for: 5m
+            labels:
+              severity: critical
+```
+
+**`spec.monitoring.serviceMonitor` fields (`AgentServiceMonitorSpec`):**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | — | Create a ServiceMonitor for this agent. **Required.** |
+| `port` | string | first port name, or `"http"` | Name of the service port to scrape |
+| `path` | string | `/metrics` | HTTP path to scrape for metrics |
+| `interval` | string | Prometheus default | Scrape interval (e.g. `"30s"`) |
+| `scrapeTimeout` | string | Prometheus default | Per-scrape timeout |
+| `labels` | map[string]string | — | Additional labels added to the ServiceMonitor metadata |
+
+**`spec.monitoring.rules[]` fields (`PrometheusRuleGroup`):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Rule group name. **Required.** |
+| `interval` | string | Evaluation interval for this group. Uses Prometheus default when omitted. |
+| `rules` | []PrometheusAlertingRule | Alerting or recording rules in this group. At least one required. |
+
+**`spec.monitoring.rules[].rules[]` fields (`PrometheusAlertingRule`):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `alert` | string | Alert name (leave empty for recording rules) |
+| `record` | string | Output metric name for recording rules (leave empty for alerting rules) |
+| `expr` | string | PromQL expression. **Required.** |
+| `for` | string | Duration condition must be true before alert fires (alerting rules only) |
+| `labels` | map[string]string | Labels attached to the alert or recording rule |
+| `annotations` | map[string]string | Annotations attached to the alert (alerting rules only) |
+
+!!! note "Requires prometheus-operator"
+    The operator creates `ServiceMonitor` and `PrometheusRule` resources only when prometheus-operator CRDs are present in the cluster. If prometheus-operator is not installed, `spec.monitoring` is silently ignored.
 
 ## Related Resources
 

--- a/docs/components/agents.md
+++ b/docs/components/agents.md
@@ -67,7 +67,7 @@ Additional variables from `spec.deployment.env` and `spec.deployment.envFrom` ar
 
 ## Workspace
 
-When `spec.workspace.enabled` is true (the default), the operator provisions a PersistentVolumeClaim named `<agent-name>-workspace` and mounts it into the agent container and all init containers. The workspace survives pod restarts and redeployments — it's deleted only when the LanguageAgent itself is deleted.
+When `spec.workspace.enabled` is true (the default), the operator provisions a PersistentVolumeClaim named `<agent-name>-workspace` and mounts it into the agent container and all init containers. The workspace survives pod restarts and redeployments. By default the PVC is deleted when the LanguageAgent is deleted; set `spec.workspace.retain: true` to preserve it.
 
 | Field | Default | Description |
 |-------|---------|-------------|
@@ -75,7 +75,10 @@ When `spec.workspace.enabled` is true (the default), the operator provisions a P
 | `spec.workspace.size` | `10Gi` | PVC storage request |
 | `spec.workspace.mountPath` | `/workspace` | Mount path in the container |
 | `spec.workspace.storageClassName` | cluster default | StorageClass for the PVC |
-| `spec.workspace.accessMode` | `ReadWriteOnce` | PVC access mode |
+| `spec.workspace.accessMode` | `ReadWriteOnce` | PVC access mode (`ReadWriteOnce` or `ReadWriteMany`) |
+| `spec.workspace.retain` | `false` | When `true`, the PVC is preserved after agent deletion; the orphaned PVC name is recorded in `status.workspacePVCName` |
+| `spec.workspace.initialFiles` | — | Files seeded into the workspace on first boot (keys = filenames, values = file contents; not overwritten if already present) |
+| `spec.workspace.seedConfigMapRef` | — | External ConfigMap whose keys/values are seeded as files; merged with `initialFiles` (`initialFiles` wins on collision) |
 
 The volume is named `workspace` in the pod spec. Init containers that need to pre-seed it should mount it by that name.
 


### PR DESCRIPTION
## Summary

- `docs/api/languageagent.md`: adds a Workspace section with a complete `WorkspaceSpec` field table (including the previously undocumented `retain`, `initialFiles`, and `seedConfigMapRef` fields, plus `status.workspacePVCName`) and a Monitoring section covering `AgentServiceMonitorSpec`, `PrometheusRuleGroup`, and `PrometheusAlertingRule` with a usage example
- `docs/components/agents.md`: extends the workspace field table with `retain`, `initialFiles`, `seedConfigMapRef`; corrects the workspace deletion claim ("deleted only when the LanguageAgent itself is deleted") to note that `retain: true` preserves the PVC

## Test plan

- [ ] Verify new workspace fields (`retain`, `initialFiles`, `seedConfigMapRef`) match `WorkspaceSpec` in `src/api/v1alpha1/languageagent_types.go`
- [ ] Verify monitoring field tables match `AgentMonitoringSpec`, `AgentServiceMonitorSpec`, `PrometheusRuleGroup`, and `PrometheusAlertingRule`
- [ ] Confirm the prometheus-operator note is present
- [ ] Check `status.workspacePVCName` description matches the type comment in `languageagent_types.go`

Closes #866

🤖 Generated with [Claude Code](https://claude.com/claude-code)