### PR TITLE
feat: clone spec.repository into the workspace via init container

### DIFF
--- a/src/api/v1alpha1/conditions.go
+++ b/src/api/v1alpha1/conditions.go
@@ -31,6 +31,7 @@ const (
 	ConditionWebhookRouteReady     = "WebhookRouteReady"
 	ConditionRuntimeResolved       = "RuntimeResolved"
 	ConditionWorkspaceSeeded       = "WorkspaceSeeded"
+	ConditionRepositoryCloned      = "RepositoryCloned"
 )
 
 // Condition reason constants used in SetCondition calls across all controllers.
@@ -68,6 +69,7 @@ const (
 	ReasonRuntimeApplied        = "RuntimeApplied"
 	ReasonWorkspaceSeedReady    = "WorkspaceSeedReady"
 	ReasonWorkspaceSeedError    = "WorkspaceSeedError"
+	ReasonRepositoryConfigured  = "RepositoryConfigured"
 	ReasonSecretNotFound        = "SecretNotFound"
 	ReasonNamespaceError        = "NamespaceError"
 	ReasonRBACError             = "RBACError"

--- a/src/controllers/languageagent_config.go
+++ b/src/controllers/languageagent_config.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -288,6 +289,157 @@ fi`, mountPath)
 	}
 }
 
+// repositoryImage is the git client image used by the repository init container.
+const repositoryImage = "alpine/git:latest"
+
+// workspaceMountPath returns the path the workspace PVC is mounted at, defaulting
+// to /workspace when the workspace is enabled without an explicit mountPath.
+func workspaceMountPath(agent *langopv1alpha1.LanguageAgent) string {
+	if agent.Spec.Workspace != nil && agent.Spec.Workspace.MountPath != "" {
+		return agent.Spec.Workspace.MountPath
+	}
+	return "/workspace"
+}
+
+// agentHasRepository reports whether a git repository clone is configured.
+func agentHasRepository(agent *langopv1alpha1.LanguageAgent) bool {
+	return agent.Spec.Repository != nil && strings.TrimSpace(agent.Spec.Repository.URL) != ""
+}
+
+// deriveRepoName extracts a repository directory name from a git URL, stripping a
+// trailing slash and ".git" suffix. Handles both URL forms (https://host/foo/bar.git)
+// and the scp-like SSH form (git@host:foo/bar.git), yielding "bar" in both cases.
+func deriveRepoName(rawURL string) string {
+	s := strings.TrimSuffix(strings.TrimRight(rawURL, "/"), ".git")
+	if i := strings.LastIndexAny(s, "/:"); i >= 0 {
+		s = s[i+1:]
+	}
+	if s == "" {
+		return "repository"
+	}
+	return s
+}
+
+// repositoryDir returns the absolute path the repository is cloned into:
+// <workspace mountPath>/<spec.repository.path or derived repo name>. Empty when
+// no repository is configured.
+func repositoryDir(agent *langopv1alpha1.LanguageAgent) string {
+	if !agentHasRepository(agent) {
+		return ""
+	}
+	sub := agent.Spec.Repository.Path
+	if sub == "" {
+		sub = deriveRepoName(agent.Spec.Repository.URL)
+	}
+	return filepath.Join(workspaceMountPath(agent), sub)
+}
+
+// buildRepositoryVolumes returns the pod-level volume holding git credentials when
+// spec.repository.secretRef is set. The Secret is mounted read-only into the
+// repository init container; the operator never reads its contents.
+func buildRepositoryVolumes(agent *langopv1alpha1.LanguageAgent) []corev1.Volume {
+	if !agentHasRepository(agent) || agent.Spec.Repository.SecretRef == nil {
+		return nil
+	}
+	mode := int32(0o400)
+	return []corev1.Volume{
+		{
+			Name: "repository-credentials",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  agent.Spec.Repository.SecretRef.Name,
+					DefaultMode: &mode,
+				},
+			},
+		},
+	}
+}
+
+// buildRepositoryInitContainer returns the "repository" init container that clones
+// spec.repository into the workspace, or nil when no repository is configured. The
+// clone uses clone-once semantics (skipped when the target already contains a .git
+// directory), so agent edits and commits survive pod restarts — mirroring the
+// workspace-seeder's seed-once behavior.
+//
+// Credentials are detected at runtime from the mounted Secret (the operator does not
+// read the Secret): an ssh-privatekey key configures GIT_SSH_COMMAND, otherwise a
+// token or username+password pair configures a GIT_ASKPASS helper for HTTPS.
+func buildRepositoryInitContainer(agent *langopv1alpha1.LanguageAgent) *corev1.Container {
+	if !agentHasRepository(agent) {
+		return nil
+	}
+
+	repo := agent.Spec.Repository
+	target := repositoryDir(agent)
+	mountPath := workspaceMountPath(agent)
+
+	depthFlag := ""
+	if repo.Depth > 0 {
+		depthFlag = fmt.Sprintf("--depth %d", repo.Depth)
+	}
+
+	script := fmt.Sprintf(`set -e
+TARGET=%q
+URL=%q
+REF=%q
+if [ -d "$TARGET/.git" ]; then
+  echo "repository already present at $TARGET, skipping clone"
+  exit 0
+fi
+SECRET_DIR=/git-secret
+if [ -d "$SECRET_DIR" ]; then
+  if [ -f "$SECRET_DIR/ssh-privatekey" ]; then
+    install -m 600 "$SECRET_DIR/ssh-privatekey" /tmp/git-ssh-key
+    export GIT_SSH_COMMAND="ssh -i /tmp/git-ssh-key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+  else
+    cat > /tmp/git-askpass <<'ASKPASS'
+#!/bin/sh
+case "$1" in
+  Username*) if [ -f /git-secret/username ]; then cat /git-secret/username; else echo "x-access-token"; fi ;;
+  Password*) if [ -f /git-secret/password ]; then cat /git-secret/password; else cat /git-secret/token; fi ;;
+esac
+ASKPASS
+    chmod +x /tmp/git-askpass
+    export GIT_ASKPASS=/tmp/git-askpass
+    export GIT_TERMINAL_PROMPT=0
+  fi
+fi
+if [ -n "$REF" ]; then
+  git clone %s --branch "$REF" "$URL" "$TARGET" 2>/dev/null || {
+    rm -rf "$TARGET"
+    git clone "$URL" "$TARGET"
+    git -C "$TARGET" checkout "$REF"
+  }
+else
+  git clone %s "$URL" "$TARGET"
+fi
+echo "cloned $URL into $TARGET"`, target, repo.URL, repo.Ref, depthFlag, depthFlag)
+
+	mounts := []corev1.VolumeMount{
+		{
+			Name:      "workspace",
+			MountPath: mountPath,
+		},
+	}
+	if repo.SecretRef != nil {
+		mounts = append(mounts, corev1.VolumeMount{
+			Name:      "repository-credentials",
+			MountPath: "/git-secret",
+			ReadOnly:  true,
+		})
+	}
+
+	return &corev1.Container{
+		Name:         "repository",
+		Image:        repositoryImage,
+		Command:      []string{"/bin/sh", "-c", script},
+		VolumeMounts: mounts,
+		Env: []corev1.EnvVar{
+			{Name: "HOME", Value: "/tmp"},
+		},
+	}
+}
+
 func (r *LanguageAgentReconciler) buildAgentEnv(ctx context.Context, agent *langopv1alpha1.LanguageAgent, cluster *langopv1alpha1.LanguageCluster, modelURLs []string, modelNames []string, toolURLs []string) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
@@ -310,6 +462,15 @@ func (r *LanguageAgentReconciler) buildAgentEnv(ctx context.Context, agent *lang
 			Name:  "AGENT_CLUSTER_UUID",
 			Value: string(cluster.UID),
 		},
+	}
+
+	// AGENT_REPO_DIR points at the cloned repository so the runtime (and any init
+	// containers) can open inside it. Injected into every container per spec/agents.md.
+	if dir := repositoryDir(agent); dir != "" {
+		env = append(env, corev1.EnvVar{
+			Name:  "AGENT_REPO_DIR",
+			Value: dir,
+		})
 	}
 
 	// Pass through OpenTelemetry collector endpoint from operator environment.

--- a/src/controllers/languageagent_config_test.go
+++ b/src/controllers/languageagent_config_test.go
@@ -895,6 +895,182 @@ func TestLanguageAgentController_WorkspaceSeed_ConditionSet(t *testing.T) {
 	assert.Equal(t, langopv1alpha1.ReasonWorkspaceSeedReady, seededCond.Reason)
 }
 
+// findInitContainer returns the named init container from a deployment, or nil.
+func findInitContainer(deployment *appsv1.Deployment, name string) *corev1.Container {
+	for i := range deployment.Spec.Template.Spec.InitContainers {
+		if deployment.Spec.Template.Spec.InitContainers[i].Name == name {
+			return &deployment.Spec.Template.Spec.InitContainers[i]
+		}
+	}
+	return nil
+}
+
+func TestDeriveRepoName(t *testing.T) {
+	cases := map[string]string{
+		"https://github.com/foo/bar.git":  "bar",
+		"https://github.com/foo/bar":      "bar",
+		"https://github.com/foo/bar.git/": "bar",
+		"git@github.com:foo/bar.git":      "bar",
+		"git@github.com:bar.git":          "bar",
+		"ssh://git@host/foo/baz":          "baz",
+	}
+	for url, want := range cases {
+		assert.Equal(t, want, deriveRepoName(url), "deriveRepoName(%q)", url)
+	}
+}
+
+func TestLanguageAgentController_Repository_InitContainerAndWorkingDir(t *testing.T) {
+	agent := gen.LanguageAgent("repo-agent", "default",
+		gen.SetAgentWorkspace("5Gi"),
+		gen.SetAgentRepository("https://github.com/foo/bar.git", "main", "", ""),
+		gen.SetAgentRepositoryDepth(1),
+	)
+	r, fakeClient := newSeedReconciler(t, agent, gen.ReadyCluster("default"))
+	reconcileTwice(t, r, agent.Name, agent.Namespace)
+
+	ctx := context.Background()
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, deployment))
+
+	repo := findInitContainer(deployment, "repository")
+	require.NotNil(t, repo, "expected repository init container")
+	assert.Equal(t, "alpine/git:latest", repo.Image)
+
+	// Clone-once semantics and ref/depth reflected in the script.
+	require.Len(t, repo.Command, 3)
+	script := repo.Command[2]
+	assert.Contains(t, script, `if [ -d "$TARGET/.git" ]; then`, "clone-once guard must be present")
+	assert.Contains(t, script, "/workspace/bar", "target dir derived from repo name")
+	assert.Contains(t, script, "--branch", "ref must be honored")
+	assert.Contains(t, script, "--depth 1", "depth must be honored")
+
+	// Must mount the workspace PVC.
+	var hasWorkspace bool
+	for _, vm := range repo.VolumeMounts {
+		if vm.Name == "workspace" {
+			hasWorkspace = true
+		}
+	}
+	assert.True(t, hasWorkspace, "repository init container must mount workspace")
+
+	// Main container opens inside the cloned repo.
+	assert.Equal(t, "/workspace/bar", deployment.Spec.Template.Spec.Containers[0].WorkingDir)
+
+	// Init container order: workspace-seeder is absent (no seed), repository runs first.
+	require.NotEmpty(t, deployment.Spec.Template.Spec.InitContainers)
+	assert.Equal(t, "repository", deployment.Spec.Template.Spec.InitContainers[0].Name)
+}
+
+func TestLanguageAgentController_Repository_AgentRepoDirInjected(t *testing.T) {
+	agent := gen.LanguageAgent("repo-env-agent", "default",
+		gen.SetAgentWorkspace("5Gi"),
+		gen.SetAgentWorkspaceMountPath("/data"),
+		gen.SetAgentRepository("https://github.com/foo/bar.git", "", "src/app", ""),
+	)
+	r, fakeClient := newSeedReconciler(t, agent, gen.ReadyCluster("default"))
+	reconcileTwice(t, r, agent.Name, agent.Namespace)
+
+	ctx := context.Background()
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, deployment))
+
+	hasRepoDir := func(env []corev1.EnvVar) bool {
+		for _, e := range env {
+			if e.Name == "AGENT_REPO_DIR" {
+				assert.Equal(t, "/data/src/app", e.Value)
+				return true
+			}
+		}
+		return false
+	}
+
+	assert.True(t, hasRepoDir(deployment.Spec.Template.Spec.Containers[0].Env), "AGENT_REPO_DIR must be set on the main container")
+	repo := findInitContainer(deployment, "repository")
+	require.NotNil(t, repo)
+	// Explicit path overrides the derived name for WorkingDir too.
+	assert.Equal(t, "/data/src/app", deployment.Spec.Template.Spec.Containers[0].WorkingDir)
+}
+
+func TestLanguageAgentController_Repository_SecretRefMounted(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "git-creds", Namespace: "default"},
+		Data:       map[string][]byte{"token": []byte("abc")},
+	}
+	agent := gen.LanguageAgent("repo-secret-agent", "default",
+		gen.SetAgentWorkspace("5Gi"),
+		gen.SetAgentRepository("https://github.com/foo/bar.git", "", "", "git-creds"),
+	)
+	r, fakeClient := newSeedReconciler(t, agent, gen.ReadyCluster("default"), secret)
+	reconcileTwice(t, r, agent.Name, agent.Namespace)
+
+	ctx := context.Background()
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, deployment))
+
+	repo := findInitContainer(deployment, "repository")
+	require.NotNil(t, repo)
+	var hasCredMount bool
+	for _, vm := range repo.VolumeMounts {
+		if vm.Name == "repository-credentials" {
+			assert.Equal(t, "/git-secret", vm.MountPath)
+			hasCredMount = true
+		}
+	}
+	assert.True(t, hasCredMount, "repository init container must mount git credentials")
+
+	// Pod volume must reference the Secret.
+	var credVol *corev1.Volume
+	for i := range deployment.Spec.Template.Spec.Volumes {
+		if deployment.Spec.Template.Spec.Volumes[i].Name == "repository-credentials" {
+			credVol = &deployment.Spec.Template.Spec.Volumes[i]
+		}
+	}
+	require.NotNil(t, credVol, "pod volumes must include repository-credentials")
+	require.NotNil(t, credVol.Secret)
+	assert.Equal(t, "git-creds", credVol.Secret.SecretName)
+}
+
+func TestLanguageAgentController_Repository_AbsentWhenNoRepository(t *testing.T) {
+	agent := gen.LanguageAgent("no-repo-agent", "default", gen.SetAgentWorkspace("5Gi"))
+	r, fakeClient := newSeedReconciler(t, agent, gen.ReadyCluster("default"))
+	reconcileTwice(t, r, agent.Name, agent.Namespace)
+
+	ctx := context.Background()
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, deployment))
+
+	assert.Nil(t, findInitContainer(deployment, "repository"), "no repository init container without spec.repository")
+	assert.Empty(t, deployment.Spec.Template.Spec.Containers[0].WorkingDir, "WorkingDir must be unset without a repository")
+	for _, e := range deployment.Spec.Template.Spec.Containers[0].Env {
+		assert.NotEqual(t, "AGENT_REPO_DIR", e.Name, "AGENT_REPO_DIR must not be injected without a repository")
+	}
+}
+
+func TestLanguageAgentController_Repository_ConditionSet(t *testing.T) {
+	agent := gen.LanguageAgent("repo-cond-agent", "default",
+		gen.SetAgentWorkspace("5Gi"),
+		gen.SetAgentRepository("https://github.com/foo/bar.git", "", "", ""),
+	)
+	agent.Generation = 1
+	r, fakeClient := newSeedReconciler(t, agent, gen.ReadyCluster("default"))
+	reconcileTwice(t, r, agent.Name, agent.Namespace)
+
+	ctx := context.Background()
+	updated := &langopv1alpha1.LanguageAgent{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, updated))
+
+	var cond *metav1.Condition
+	for i := range updated.Status.Conditions {
+		if updated.Status.Conditions[i].Type == langopv1alpha1.ConditionRepositoryCloned {
+			cond = &updated.Status.Conditions[i]
+			break
+		}
+	}
+	require.NotNil(t, cond, "RepositoryCloned condition must be set")
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+	assert.Equal(t, langopv1alpha1.ReasonRepositoryConfigured, cond.Reason)
+}
+
 // parseAgentConfigMap reconciles the agent once and returns the parsed config.yaml from the agent ConfigMap.
 func parseAgentConfigMap(t *testing.T, scheme *runtime.Scheme, objects ...client.Object) agentConfigYAML {
 	t.Helper()

--- a/src/controllers/languageagent_controller.go
+++ b/src/controllers/languageagent_controller.go
@@ -247,6 +247,13 @@ func (r *LanguageAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		SetCondition(&agent.Status.Conditions, langopv1alpha1.ConditionWorkspaceSeeded, metav1.ConditionTrue, langopv1alpha1.ReasonWorkspaceSeedReady, "Workspace seed ConfigMap reconciled", agent.Generation)
 	}
 
+	// Repository clone is performed in-pod by the "repository" init container (clone-once).
+	// The condition reflects that the clone is configured, mirroring WorkspaceSeeded.
+	if agentHasRepository(workingAgent) {
+		SetCondition(&agent.Status.Conditions, langopv1alpha1.ConditionRepositoryCloned, metav1.ConditionTrue, langopv1alpha1.ReasonRepositoryConfigured,
+			fmt.Sprintf("Repository clone configured: %s", workingAgent.Spec.Repository.URL), agent.Generation)
+	}
+
 	// Reconcile NetworkPolicy for network isolation (if enabled)
 	if r.NetworkIsolationEnabled {
 		if err := r.reconcileNetworkPolicy(ctx, workingAgent); err != nil {

--- a/src/controllers/languageagent_deployment.go
+++ b/src/controllers/languageagent_deployment.go
@@ -100,6 +100,11 @@ func (r *LanguageAgentReconciler) reconcileDeployment(ctx context.Context, agent
 			containers = append(containers, *oauthSidecar)
 		}
 
+		// Open the runtime inside the cloned repository, when one is configured.
+		if repoDir := repositoryDir(agent); repoDir != "" {
+			containers[0].WorkingDir = repoDir
+		}
+
 		// Inject operator-managed env vars and volume mounts into user-specified init containers.
 		// Per spec/agents.md, all contracted env vars must be present in every
 		// container including init containers. The agent-config volume mount is also
@@ -117,9 +122,14 @@ func (r *LanguageAgentReconciler) reconcileDeployment(ctx context.Context, agent
 			userInitContainers[i].VolumeMounts = append([]corev1.VolumeMount{agentConfigMount}, userInitContainers[i].VolumeMounts...)
 		}
 
-		// Prepend the workspace-seeder init container so the workspace is populated
-		// before any user init containers or sidecar tools run.
+		// Prepend the repository-clone init container (right before user init
+		// containers), then the workspace-seeder ahead of it, so the final order is
+		// [workspace-seeder, repository, ...userInit, ...sidecars]. The workspace is
+		// populated and the repo cloned before any user init containers or tools run.
 		allInitContainers := userInitContainers
+		if repoContainer := buildRepositoryInitContainer(agent); repoContainer != nil {
+			allInitContainers = append([]corev1.Container{*repoContainer}, allInitContainers...)
+		}
 		if seedContainer := buildWorkspaceSeedInitContainer(agent); seedContainer != nil {
 			allInitContainers = append([]corev1.Container{*seedContainer}, allInitContainers...)
 		}
@@ -176,6 +186,8 @@ func (r *LanguageAgentReconciler) reconcileDeployment(ctx context.Context, agent
 		volumes, volumeMounts := r.buildVolumes(ctx, agent)
 		// Append seed ConfigMap volumes (not mounted in main container; used by workspace-seeder init container).
 		volumes = append(volumes, buildWorkspaceSeedVolumes(agent)...)
+		// Append git credential volume (mounted only in the repository init container).
+		volumes = append(volumes, buildRepositoryVolumes(agent)...)
 		// Append scratch volumes for stdio sidecar bridges (mounted only in their sidecar containers).
 		volumes = append(volumes, sidecarVolumes...)
 		volumes = append(volumes, agent.Spec.Deployment.Volumes...)

--- a/src/internal/testutil/gen/languageagent.go
+++ b/src/internal/testutil/gen/languageagent.go
@@ -235,3 +235,24 @@ func SetAgentServiceAccountName(name string) LanguageAgentModifier {
 		a.Spec.Deployment.ServiceAccountName = name
 	}
 }
+
+// SetAgentRepository sets spec.repository. Empty ref/path/secretRef are left unset.
+func SetAgentRepository(url, ref, path, secretRef string) LanguageAgentModifier {
+	return func(a *langopv1alpha1.LanguageAgent) {
+		repo := &langopv1alpha1.RepositorySpec{URL: url, Ref: ref, Path: path}
+		if secretRef != "" {
+			repo.SecretRef = &corev1.LocalObjectReference{Name: secretRef}
+		}
+		a.Spec.Repository = repo
+	}
+}
+
+// SetAgentRepositoryDepth sets spec.repository.depth, initialising the repository if needed.
+func SetAgentRepositoryDepth(depth int) LanguageAgentModifier {
+	return func(a *langopv1alpha1.LanguageAgent) {
+		if a.Spec.Repository == nil {
+			a.Spec.Repository = &langopv1alpha1.RepositorySpec{}
+		}
+		a.Spec.Repository.Depth = depth
+	}
+}


### PR DESCRIPTION
Closes #878

## Summary
Implements the operator-side clone of `spec.repository` (CRD added in #880). A `repository` init container clones the configured git repo into the agent workspace at pod startup, and the runtime opens inside it.

## Changes
- **`repository` init container** (`alpine/git:latest`) inserted after `workspace-seeder`, before user init containers. Clone-once semantics — skipped when `<target>/.git` already exists, so agent edits/commits survive pod restarts.
- **Credentials** detected at runtime from a mounted `secretRef` Secret (operator never reads it): `ssh-privatekey` → `GIT_SSH_COMMAND`; otherwise `token` or `username`+`password` → `GIT_ASKPASS` for HTTPS.
- **`ref`/`depth`** honored — `--branch` for branch/tag (shallow-compatible), with a full-clone + `git checkout` fallback for SHAs.
- **Target dir** = `<workspace mountPath>/<spec.repository.path or derived repo name>`. Main container `WorkingDir` set to it; `AGENT_REPO_DIR` injected into main + init containers.
- **`RepositoryCloned`** status condition set when a repository is configured (mirrors `WorkspaceSeeded`).

## Tests
- Init container present with clone-once script, ref/depth reflected, `WorkingDir` set
- `AGENT_REPO_DIR` injected; honors explicit `path` and custom `mountPath`
- `secretRef` mounts `repository-credentials` at `/git-secret`
- No `repository` container / no `AGENT_REPO_DIR` when `spec.repository` is nil
- `RepositoryCloned` condition set; `deriveRepoName` URL-form coverage

No CRD type changes (type added in #880), so no generated-file updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)