### PR TITLE
docs: document spec.repository and AGENT_REPO_DIR for LanguageAgent

### DIFF
--- a/docs/api/languageagent.md
+++ b/docs/api/languageagent.md
@@ -216,6 +216,7 @@ Environment variables injected into every agent container and all init container
 | `LLM_MODEL` | Comma-separated list of model names for all referenced models |
 | `MCP_SERVERS` | Comma-separated MCP tool server URLs (only injected when at least one tool is resolved) |
 | `AGENT_INSTRUCTIONS` | Content of `spec.instructions`; only set when instructions are non-empty |
+| `AGENT_REPO_DIR` | Absolute path to the cloned repository (the agent container's working directory). Only injected when `spec.repository` is set. See [Repository](#repository). |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Propagated from the operator environment when configured |
 | `OTEL_SERVICE_NAME` | Set to `agent-<name>` when `OTEL_EXPORTER_OTLP_ENDPOINT` is configured |
 | `OTEL_RESOURCE_ATTRIBUTES` | Propagated from the operator environment (conditional on OTEL endpoint) |
@@ -242,6 +243,55 @@ When `spec.workspace.enabled` is true (the default), the operator provisions a P
 | `seedConfigMapRef` | *LocalObjectReference | — | External ConfigMap whose keys are filenames and values are file contents. Merged with `initialFiles`; `initialFiles` wins on key collision. |
 
 When `retain` is `true` and the agent is deleted, `status.workspacePVCName` records the name of the orphaned PVC so it can be located and reattached later.
+
+### Repository
+
+When `spec.repository` is set, the operator adds a `repository` init container that clones a git repository into the workspace before the agent starts. The agent container's working directory is set to the clone path, and `AGENT_REPO_DIR` is injected into every container so the runtime can locate it.
+
+The clone is **clone-once**: if the target directory already contains a `.git` directory the clone is skipped, so edits and commits made by the agent survive pod restarts. Because the clone lands in the workspace, declaring `spec.repository` automatically defaults `spec.workspace.enabled` to `true`; declaring a repository while `spec.workspace.enabled` is explicitly `false` is rejected by the webhook.
+
+**`spec.repository` fields (`RepositorySpec`):**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `url` | string | — | Git repository to clone, either HTTPS (`https://...`) or SSH (`git@host:org/repo.git`). **Required.** |
+| `ref` | string | default branch | Branch, tag, or commit SHA to check out. |
+| `path` | string | repo name from URL | Subdirectory under the workspace `mountPath` to clone into. Must be relative (no leading `/`, no `..` segments). |
+| `depth` | int | `0` (full clone) | When > 0, performs a shallow clone with this history depth. |
+| `secretRef` | *LocalObjectReference | — | Secret holding git credentials for private repositories. Recognized keys: `token`, or `username` + `password` (HTTPS); `ssh-privatekey` (SSH). |
+
+The clone target is `<workspace mountPath>/<path>` — e.g. with the default `mountPath: /workspace` and `path: app`, the repository is cloned to `/workspace/app` and `AGENT_REPO_DIR` is set to `/workspace/app`. When `path` is omitted, the directory name is derived from the URL (e.g. `https://github.com/org/repo.git` → `/workspace/repo`).
+
+The operator never reads the credentials Secret; it is mounted read-only into the `repository` init container, which selects SSH or HTTPS auth based on which keys are present.
+
+**Private repository example (HTTPS token):**
+
+```yaml
+apiVersion: langop.io/v1alpha1
+kind: LanguageAgent
+metadata:
+  name: code-agent
+  namespace: default
+spec:
+  image: myregistry/agent-runtime:latest
+  repository:
+    url: https://github.com/myorg/private-repo.git
+    ref: main
+    path: app
+    depth: 1
+    secretRef:
+      name: git-credentials
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: git-credentials
+  namespace: default
+type: Opaque
+stringData:
+  token: ghp_xxxxxxxxxxxxxxxxxxxx   # a personal access token (HTTPS)
+  # For SSH instead, provide an ssh-privatekey key and a git@host:... url.
+```
 
 ### Resource Management
 

--- a/docs/components/agents.md
+++ b/docs/components/agents.md
@@ -60,6 +60,7 @@ The operator injects these into the agent container and all init containers:
 | `LLM_MODEL` | Comma-separated list of model names for all referenced models |
 | `MCP_SERVERS` | Comma-separated tool endpoint URLs — service-mode tools use in-cluster DNS; sidecar-mode tools use `http://localhost:<port>/mcp` |
 | `AGENT_INSTRUCTIONS` | Content of `spec.instructions`; only set when non-empty |
+| `AGENT_REPO_DIR` | Absolute path to the cloned repository; also the agent's working directory. Only injected when `spec.repository` is set |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Propagated from the operator when configured |
 | `OTEL_SERVICE_NAME` | Set to `agent-<name>` when OTEL is configured |
 
@@ -81,6 +82,22 @@ When `spec.workspace.enabled` is true (the default), the operator provisions a P
 | `spec.workspace.seedConfigMapRef` | — | External ConfigMap whose keys/values are seeded as files; merged with `initialFiles` (`initialFiles` wins on collision) |
 
 The volume is named `workspace` in the pod spec. Init containers that need to pre-seed it should mount it by that name.
+
+## Repository
+
+When `spec.repository` is set, the operator adds a `repository` init container (image `alpine/git:latest`) that runs after the workspace seeder and clones a git repository into the workspace. The agent container's working directory is set to the clone path, and `AGENT_REPO_DIR` is injected into every container.
+
+The clone is **clone-once**: it is skipped when the target directory already contains a `.git` directory, so the agent's edits and commits survive pod restarts. Declaring `spec.repository` defaults `spec.workspace.enabled` to `true`, since the clone needs the workspace PVC to land in.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `spec.repository.url` | — | Git repository to clone — HTTPS (`https://...`) or SSH (`git@host:org/repo.git`). Required |
+| `spec.repository.ref` | default branch | Branch, tag, or commit SHA to check out |
+| `spec.repository.path` | repo name from URL | Subdirectory under the workspace `mountPath` to clone into (relative path only) |
+| `spec.repository.depth` | `0` | When > 0, shallow-clone to this history depth |
+| `spec.repository.secretRef` | — | Secret with git credentials for private repos. Keys: `token` or `username`+`password` (HTTPS), `ssh-privatekey` (SSH) |
+
+When `secretRef` is set, the Secret is mounted read-only into the `repository` init container at `/git-secret`; the operator never reads its contents. The init container picks SSH or HTTPS authentication based on which keys are present. See the [LanguageAgent API reference](../api/languageagent.md#repository) for a full private-repo example.
 
 ## Networking
 

--- a/spec/agents.md
+++ b/spec/agents.md
@@ -49,6 +49,23 @@ initContainers:
         mountPath: /workspace
 ```
 
+### Repository Cloning
+
+When `spec.repository` is set, the operator injects a `repository` init container (image `alpine/git:latest`) that runs after the `workspace-seeder` and clones the configured git repository into the workspace before the agent container starts:
+
+| Path | Content |
+|------|---------|
+| `AGENT_REPO_DIR` (`<workspace mountPath>/<spec.repository.path or repo name>`) | The cloned git repository, on the read-write workspace volume |
+
+Key behaviors a runtime can rely on:
+
+- **Clone-once.** The init container clones only when the target directory does not already contain a `.git` directory. On subsequent restarts the existing checkout — including any agent edits and commits — is left untouched.
+- **Working directory.** The operator sets the agent container's working directory to `AGENT_REPO_DIR`, and injects the same path as an env var into every container. A compliant runtime should open and operate inside this directory.
+- **Workspace required.** The clone lands on the workspace volume, so configuring a repository implies a workspace PVC; the operator defaults `spec.workspace.enabled` to `true` when a repository is set.
+- **Credentials.** For private repositories, `spec.repository.secretRef` names a Secret mounted read-only into the `repository` init container at `/git-secret`. The operator never reads it; the init container selects SSH (`ssh-privatekey` key) or HTTPS (`token`, or `username` + `password` keys) authentication based on which keys are present.
+
+The clone uses `spec.repository.ref` for the branch/tag/commit and `spec.repository.depth` for an optional shallow clone. See the [LanguageAgent API reference](../docs/api/languageagent.md#repository) for the full field reference and a private-repo example.
+
 ### Environment Variables
 
 The operator injects the following environment variables into every agent container and all init containers:
@@ -64,6 +81,7 @@ The operator injects the following environment variables into every agent contai
 | `LLM_MODEL` | Comma-separated list of model names for all referenced models |
 | `MCP_SERVERS` | Comma-separated full MCP tool URLs (each already includes the `/mcp` path) for all resolved tools — service-mode tools use `http://<name>.<ns>.svc.cluster.local:<port>/mcp`; sidecar-mode tools use `http://localhost:<port>/mcp`. The runtime connects to each URL directly as a Streamable HTTP MCP server (stdio tools are bridged to Streamable HTTP by the operator). Only injected when at least one tool is resolved. |
 | `AGENT_INSTRUCTIONS` | Content of `spec.instructions`; only set when instructions are non-empty. Identical to the `instructions` field in `/etc/agent/config.yaml`. |
+| `AGENT_REPO_DIR` | Absolute path to the repository cloned from `spec.repository`. Only injected when a repository is configured. The operator also sets the agent container's working directory to this path, so a compliant runtime should operate inside it. See [Repository Cloning](#repository-cloning). |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Propagated from the operator environment when configured; enables agent-side OTEL tracing |
 | `OTEL_SERVICE_NAME` | Set to `agent-<name>` when `OTEL_EXPORTER_OTLP_ENDPOINT` is configured |
 | `OTEL_RESOURCE_ATTRIBUTES` | Propagated from the operator environment when set (conditional on `OTEL_EXPORTER_OTLP_ENDPOINT`) |

--- a/src/docs/api-reference.md
+++ b/src/docs/api-reference.md
@@ -11,11 +11,29 @@ Package v1alpha1 contains API Schema definitions for the language v1alpha1 API g
 ### Resource Types
 - [LanguageAgent](#languageagent)
 - [LanguageAgentRuntime](#languageagentruntime)
+- [LanguageAgentSelfConfig](#languageagentselfconfig)
 - [LanguageCluster](#languagecluster)
 - [LanguageModel](#languagemodel)
 - [LanguagePersona](#languagepersona)
 - [LanguageTool](#languagetool)
 
+
+
+#### AgentMonitoringSpec
+
+
+
+AgentMonitoringSpec defines Prometheus Operator integration for a LanguageAgent.
+
+
+
+_Appears in:_
+- [LanguageAgentSpec](#languageagentspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `serviceMonitor` _[AgentServiceMonitorSpec](#agentservicemonitorspec)_ | ServiceMonitor configures a ServiceMonitor resource for this agent. |  | Optional: \{\} <br /> |
+| `rules` _[PrometheusRuleGroup](#prometheusrulegroup) array_ | Rules defines PrometheusRule groups for this agent.<br />When non-empty, the operator creates a PrometheusRule resource. |  | Optional: \{\} <br /> |
 
 
 #### AgentNetworkPolicies
@@ -35,8 +53,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `ingress` _[NetworkIngressRule](#networkingressrule) array_ | Ingress rules — each entry allows traffic into the workload from the listed sources. |  |  |
-| `egress` _[NetworkEgressRule](#networkegressrule) array_ | Egress rules — each entry allows traffic from the workload to the listed destinations. |  |  |
+| `ingress` _[NetworkIngressRule](#networkingressrule) array_ | Ingress rules — each entry allows traffic into the workload from the listed sources. |  | Optional: \{\} <br /> |
+| `egress` _[NetworkEgressRule](#networkegressrule) array_ | Egress rules — each entry allows traffic from the workload to the listed destinations. |  | Optional: \{\} <br /> |
 
 
 #### AgentPort
@@ -55,25 +73,64 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `name` _string_ | Name uniquely identifies this port within the agent (e.g., "web", "ws").<br />Used as the Service port name; must conform to Kubernetes port-name rules. |  | MaxLength: 15 <br />Pattern: `^[a-z][a-z0-9-]*$` <br />Required: \{\} <br /> |
 | `port` _integer_ | Port is the port number the container listens on. |  | Maximum: 65535 <br />Minimum: 1 <br />Required: \{\} <br /> |
-| `protocol` _[Protocol](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#protocol-v1-core)_ | Protocol is the transport protocol. Defaults to TCP. | TCP | Enum: [TCP UDP SCTP] <br /> |
-| `expose` _boolean_ | Expose controls whether ingress/HTTPRoute routes to this port.<br />At most one port should have expose: true; if none, the first port is used. |  |  |
+| `protocol` _[Protocol](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#protocol-v1-core)_ | Protocol is the transport protocol. Defaults to TCP. | TCP | Enum: [TCP UDP SCTP] <br />Optional: \{\} <br /> |
+| `expose` _boolean_ | Expose controls whether ingress/HTTPRoute routes to this port.<br />At most one port should have expose: true; if none, the first port is used. | false | Optional: \{\} <br /> |
 
 
-#### CertIssuerReference
+#### AgentServiceMonitorSpec
 
 
 
-CertIssuerReference references a cert-manager issuer
+AgentServiceMonitorSpec configures a Prometheus Operator ServiceMonitor for an agent.
 
 
 
 _Appears in:_
-- [IngressTLSConfig](#ingresstlsconfig)
+- [AgentMonitoringSpec](#agentmonitoringspec)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `name` _string_ | Name of the Issuer or ClusterIssuer |  | Required: \{\} <br /> |
-| `kind` _string_ | Kind is either "Issuer" or "ClusterIssuer" | ClusterIssuer | Enum: [Issuer ClusterIssuer] <br /> |
+| `enabled` _boolean_ | Enabled controls whether a ServiceMonitor is created for this agent. |  |  |
+| `port` _string_ | Port is the name of the service port to scrape for metrics.<br />Defaults to the name of the first port in spec.ports, or "http" if no ports are defined. |  | Optional: \{\} <br /> |
+| `path` _string_ | Path is the HTTP path to scrape for metrics. Defaults to /metrics. |  | Optional: \{\} <br /> |
+| `interval` _string_ | Interval is the scrape interval (e.g. "30s"). Uses the Prometheus default when omitted. |  | Optional: \{\} <br /> |
+| `scrapeTimeout` _string_ | ScrapeTimeout is the per-scrape timeout. Uses the Prometheus default when omitted. |  | Optional: \{\} <br /> |
+| `labels` _object (keys:string, values:string)_ | Labels are additional labels added to the ServiceMonitor metadata. |  | Optional: \{\} <br /> |
+
+
+#### AutoscalingSpec
+
+
+
+AutoscalingSpec configures a HorizontalPodAutoscaler for the deployment.
+
+
+
+_Appears in:_
+- [DeploymentSpec](#deploymentspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `minReplicas` _integer_ | MinReplicas is the lower bound for replicas the HPA can scale down to.<br />Defaults to 1 if not specified. |  | Minimum: 1 <br />Optional: \{\} <br /> |
+| `maxReplicas` _integer_ | MaxReplicas is the upper bound for replicas the HPA can scale up to. |  | Minimum: 1 <br /> |
+| `metrics` _[MetricSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#metricspec-v2-autoscaling) array_ | Metrics specifies which metrics to use for scaling.<br />Defaults to 80% average CPU utilization if not specified. |  | Optional: \{\} <br /> |
+
+
+#### ClusterAuthSpec
+
+
+
+ClusterAuthSpec configures OIDC authentication for a LanguageCluster.
+
+
+
+_Appears in:_
+- [LanguageClusterSpec](#languageclusterspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `enabled` _boolean_ | Enabled controls whether OIDC authentication is active for this cluster. |  | Optional: \{\} <br /> |
+| `oidc` _[ClusterOIDCSpec](#clusteroidcspec)_ | OIDC configures the OIDC provider (embedded Dex or external). |  | Optional: \{\} <br /> |
 
 
 #### ClusterCapacitySpec
@@ -89,12 +146,12 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `maxAgents` _integer_ | MaxAgents is the maximum number of LanguageAgent objects allowed. |  |  |
-| `maxModels` _integer_ | MaxModels is the maximum number of LanguageModel objects allowed. |  |  |
-| `maxTools` _integer_ | MaxTools is the maximum number of LanguageTool objects allowed. |  |  |
-| `maxPersonas` _integer_ | MaxPersonas is the maximum number of LanguagePersona objects allowed. |  |  |
-| `maxCPU` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#quantity-resource-api)_ | MaxCPU is the aggregate CPU limit for all pods in the cluster namespace.<br />Maps to limits.cpu in the namespace ResourceQuota.<br />Example: "4", "2500m" |  |  |
-| `maxMemory` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#quantity-resource-api)_ | MaxMemory is the aggregate memory limit for all pods in the cluster namespace.<br />Maps to limits.memory in the namespace ResourceQuota.<br />Example: "8Gi", "512Mi" |  |  |
+| `maxAgents` _integer_ | MaxAgents is the maximum number of LanguageAgent objects allowed. |  | Optional: \{\} <br /> |
+| `maxModels` _integer_ | MaxModels is the maximum number of LanguageModel objects allowed. |  | Optional: \{\} <br /> |
+| `maxTools` _integer_ | MaxTools is the maximum number of LanguageTool objects allowed. |  | Optional: \{\} <br /> |
+| `maxPersonas` _integer_ | MaxPersonas is the maximum number of LanguagePersona objects allowed. |  | Optional: \{\} <br /> |
+| `maxCPU` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#quantity-resource-api)_ | MaxCPU is the aggregate CPU limit for all pods in the cluster namespace.<br />Maps to limits.cpu in the namespace ResourceQuota.<br />Example: "4", "2500m" |  | Optional: \{\} <br /> |
+| `maxMemory` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#quantity-resource-api)_ | MaxMemory is the aggregate memory limit for all pods in the cluster namespace.<br />Maps to limits.memory in the namespace ResourceQuota.<br />Example: "8Gi", "512Mi" |  | Optional: \{\} <br /> |
 
 
 #### ClusterCapacityStatus
@@ -114,8 +171,49 @@ _Appears in:_
 | `modelCount` _integer_ | ModelCount is the number of LanguageModel objects in the cluster namespace. |  |  |
 | `toolCount` _integer_ | ToolCount is the number of LanguageTool objects in the cluster namespace. |  |  |
 | `personaCount` _integer_ | PersonaCount is the number of LanguagePersona objects in the cluster namespace. |  |  |
-| `totalCPULimits` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#quantity-resource-api)_ | TotalCPULimits is the sum of limits.cpu across all agent pod specs. |  |  |
-| `totalMemoryLimits` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#quantity-resource-api)_ | TotalMemoryLimits is the sum of limits.memory across all agent pod specs. |  |  |
+| `totalCPULimits` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#quantity-resource-api)_ | TotalCPULimits is the sum of limits.cpu across all agent pod specs. |  | Optional: \{\} <br /> |
+| `totalMemoryLimits` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#quantity-resource-api)_ | TotalMemoryLimits is the sum of limits.memory across all agent pod specs. |  | Optional: \{\} <br /> |
+
+
+#### ClusterOIDCSpec
+
+
+
+ClusterOIDCSpec configures the OIDC provider for the cluster.
+
+
+
+_Appears in:_
+- [ClusterAuthSpec](#clusterauthspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `dex` _[DexSpec](#dexspec)_ | Dex configures the embedded Dex OIDC provider.<br />When set (and ExternalIssuerURL is not), the controller deploys Dex alongside the gateway. |  | Optional: \{\} <br /> |
+| `externalIssuerURL` _string_ | ExternalIssuerURL skips deploying Dex and uses this issuer URL for oauth2-proxy.<br />Mutually exclusive with dex.<br />Example: "https://accounts.google.com" |  | Optional: \{\} <br /> |
+| `clientID` _string_ | ClientID is the OAuth2 client ID when using an external OIDC provider.<br />Ignored when dex is configured (the operator manages the client ID). |  | Optional: \{\} <br /> |
+| `clientSecretRef` _[SecretReference](#secretreference)_ | ClientSecretRef references a Secret containing the OAuth2 client secret.<br />Ignored when dex is configured (the operator manages the client secret). |  | Optional: \{\} <br /> |
+| `emailDomain` _string_ | EmailDomain restricts login to users with this email domain.<br />Set to "*" to allow all email domains (default). |  | Optional: \{\} <br /> |
+
+
+#### CredentialSpec
+
+
+
+CredentialSpec declares an environment variable backed by a Secret value.
+The operator resolves it once and injects it into the agent container.
+Source priority: ValueFrom (existing Secret) > Value (inline) > auto-generate.
+
+
+
+_Appears in:_
+- [LanguageAgentRuntimeSpec](#languageagentruntimespec)
+- [LanguageAgentSpec](#languageagentspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the environment variable name and the key within the operator-managed<br />Secret (e.g. OPENCLAW_GATEWAY_TOKEN, OPENCODE_SERVER_PASSWORD). |  | Required: \{\} <br /> |
+| `value` _string_ | Value, when set, is stored verbatim in the managed Secret instead of<br />generating a random credential. Mutually exclusive with ValueFrom. |  | Optional: \{\} <br /> |
+| `valueFrom` _[RuntimeSecretRef](#runtimesecretref)_ | ValueFrom references an existing Secret whose keys are injected via envFrom.<br />When set, the operator does not create or manage a Secret for this entry.<br />Mutually exclusive with Value. |  | Optional: \{\} <br /> |
 
 
 #### DeploymentSpec
@@ -136,30 +234,90 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `replicas` _integer_ | Replicas is the number of pod replicas to run. |  | Minimum: 0 <br /> |
-| `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#pullpolicy-v1-core)_ | ImagePullPolicy defines when to pull the container image. |  | Enum: [Always Never IfNotPresent] <br /> |
-| `imagePullSecrets` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core) array_ | ImagePullSecrets is a list of references to secrets for pulling images. |  |  |
-| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | Env contains environment variables for the container. |  |  |
-| `envFrom` _[EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envfromsource-v1-core) array_ | EnvFrom sources to populate environment variables. |  |  |
-| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | Resources defines compute resource requirements. |  |  |
-| `nodeSelector` _object (keys:string, values:string)_ | NodeSelector is a selector which must match a node's labels. |  |  |
-| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#affinity-v1-core)_ | Affinity defines pod affinity and anti-affinity rules. |  |  |
-| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#toleration-v1-core) array_ | Tolerations allow pods to schedule onto nodes with matching taints. |  |  |
-| `topologySpreadConstraints` _[TopologySpreadConstraint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#topologyspreadconstraint-v1-core) array_ | TopologySpreadConstraints describes how pods should spread across topology domains. |  |  |
-| `serviceAccountName` _string_ | ServiceAccountName is the name of the ServiceAccount to use. |  |  |
-| `securityContext` _[PodSecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podsecuritycontext-v1-core)_ | SecurityContext holds pod-level security attributes. |  |  |
-| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumemount-v1-core) array_ | VolumeMounts to mount into the container. |  |  |
-| `volumes` _[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volume-v1-core) array_ | Volumes to attach to the pod. |  |  |
-| `podAnnotations` _object (keys:string, values:string)_ | PodAnnotations are annotations to add to the Pods. |  |  |
-| `podLabels` _object (keys:string, values:string)_ | PodLabels are additional labels to add to the Pods. |  |  |
-| `initContainers` _[Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#container-v1-core) array_ | InitContainers are additional init containers injected before the main container starts. |  |  |
-| `livenessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | LivenessProbe defines the liveness probe for the container. |  |  |
-| `readinessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | ReadinessProbe defines the readiness probe for the container. |  |  |
-| `startupProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | StartupProbe defines the startup probe for the container. |  |  |
-| `command` _string array_ | Command overrides the container entrypoint. |  |  |
-| `args` _string array_ | Args overrides the container command arguments. |  |  |
-| `serviceType` _[ServiceType](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#servicetype-v1-core)_ | ServiceType specifies the type of Service to create (ClusterIP, NodePort, LoadBalancer). |  | Enum: [ClusterIP NodePort LoadBalancer] <br /> |
-| `serviceAnnotations` _object (keys:string, values:string)_ | ServiceAnnotations are annotations to add to the Service. |  |  |
+| `replicas` _integer_ | Replicas is the number of pod replicas to run. |  | Minimum: 0 <br />Optional: \{\} <br /> |
+| `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#pullpolicy-v1-core)_ | ImagePullPolicy defines when to pull the container image. |  | Enum: [Always Never IfNotPresent] <br />Optional: \{\} <br /> |
+| `imagePullSecrets` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core) array_ | ImagePullSecrets is a list of references to secrets for pulling images. |  | Optional: \{\} <br /> |
+| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | Env contains environment variables for the container. |  | Optional: \{\} <br /> |
+| `envFrom` _[EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envfromsource-v1-core) array_ | EnvFrom sources to populate environment variables. |  | Optional: \{\} <br /> |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | Resources defines compute resource requirements. |  | Optional: \{\} <br /> |
+| `nodeSelector` _object (keys:string, values:string)_ | NodeSelector is a selector which must match a node's labels. |  | Optional: \{\} <br /> |
+| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#affinity-v1-core)_ | Affinity defines pod affinity and anti-affinity rules. |  | Optional: \{\} <br /> |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#toleration-v1-core) array_ | Tolerations allow pods to schedule onto nodes with matching taints. |  | Optional: \{\} <br /> |
+| `topologySpreadConstraints` _[TopologySpreadConstraint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#topologyspreadconstraint-v1-core) array_ | TopologySpreadConstraints describes how pods should spread across topology domains. |  | Optional: \{\} <br /> |
+| `serviceAccountName` _string_ | ServiceAccountName is the name of the ServiceAccount to use. |  | Optional: \{\} <br /> |
+| `serviceAccountAnnotations` _object (keys:string, values:string)_ | ServiceAccountAnnotations are annotations to add to the operator-managed ServiceAccount.<br />Use this to attach cloud workload identity bindings, e.g. AWS IRSA, GCP WI, AKS WI.<br />Ignored when ServiceAccountName is set. |  | Optional: \{\} <br /> |
+| `roleRules` _[PolicyRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#policyrule-v1-rbac) array_ | RoleRules are additional RBAC policy rules appended to the operator-managed Role.<br />Use this to grant the agent extra in-cluster permissions beyond the defaults<br />(configmaps get/list, pods get/list/watch).<br />Ignored when ServiceAccountName is set. |  | Optional: \{\} <br /> |
+| `securityContext` _[PodSecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podsecuritycontext-v1-core)_ | SecurityContext holds pod-level security attributes. |  | Optional: \{\} <br /> |
+| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumemount-v1-core) array_ | VolumeMounts to mount into the container. |  | Optional: \{\} <br /> |
+| `volumes` _[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volume-v1-core) array_ | Volumes to attach to the pod. |  | Optional: \{\} <br /> |
+| `podAnnotations` _object (keys:string, values:string)_ | PodAnnotations are annotations to add to the Pods. |  | Optional: \{\} <br /> |
+| `podLabels` _object (keys:string, values:string)_ | PodLabels are additional labels to add to the Pods. |  | Optional: \{\} <br /> |
+| `initContainers` _[Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#container-v1-core) array_ | InitContainers are additional init containers injected before the main container starts. |  | Optional: \{\} <br /> |
+| `livenessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | LivenessProbe defines the liveness probe for the container. |  | Optional: \{\} <br /> |
+| `readinessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | ReadinessProbe defines the readiness probe for the container. |  | Optional: \{\} <br /> |
+| `startupProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | StartupProbe defines the startup probe for the container. |  | Optional: \{\} <br /> |
+| `command` _string array_ | Command overrides the container entrypoint. |  | Optional: \{\} <br /> |
+| `args` _string array_ | Args overrides the container command arguments. |  | Optional: \{\} <br /> |
+| `serviceType` _[ServiceType](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#servicetype-v1-core)_ | ServiceType specifies the type of Service to create (ClusterIP, NodePort, LoadBalancer). |  | Enum: [ClusterIP NodePort LoadBalancer] <br />Optional: \{\} <br /> |
+| `serviceAnnotations` _object (keys:string, values:string)_ | ServiceAnnotations are annotations to add to the Service. |  | Optional: \{\} <br /> |
+| `autoscaling` _[AutoscalingSpec](#autoscalingspec)_ | Autoscaling enables and configures a HorizontalPodAutoscaler for this deployment.<br />When set, the HPA manages the replica count; spec.deployment.replicas is used as<br />the initial desired count only and is no longer written on each reconcile. |  | Optional: \{\} <br /> |
+
+
+#### DexConnector
+
+
+
+DexConnector configures a Dex upstream identity provider connector.
+
+
+
+_Appears in:_
+- [DexSpec](#dexspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `type` _string_ | Type is the connector type: "github", "google", "oidc", "ldap", "microsoft", "saml", etc.<br />See https://dexidp.io/docs/connectors/ for the full list. |  | Required: \{\} <br /> |
+| `id` _string_ | ID is the connector's unique identifier. |  | Required: \{\} <br /> |
+| `name` _string_ | Name is the human-readable display name shown on the Dex login page. |  | Required: \{\} <br /> |
+| `config` _object (keys:string, values:string)_ | Config contains connector-specific configuration key/value pairs. |  | Optional: \{\} <br /> |
+
+
+#### DexSpec
+
+
+
+DexSpec configures the embedded Dex OIDC provider.
+
+
+
+_Appears in:_
+- [ClusterOIDCSpec](#clusteroidcspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `connectors` _[DexConnector](#dexconnector) array_ | Connectors configures upstream identity providers (GitHub, Google, OIDC, etc.). |  | Optional: \{\} <br /> |
+| `enablePasswordDB` _boolean_ | EnablePasswordDB enables Dex's built-in local password store.<br />When true, Dex presents a username/password login form backed by StaticPasswords.<br />This is independent of connectors — both can be active simultaneously. |  | Optional: \{\} <br /> |
+| `staticPasswords` _[DexStaticPassword](#dexstaticpassword) array_ | StaticPasswords defines local user accounts for Dex's built-in password store.<br />Only used when EnablePasswordDB is true. |  | Optional: \{\} <br /> |
+| `image` _string_ | Image overrides the Dex container image.<br />Defaults to the operator Helm chart's config.auth.dex.image value. |  | Optional: \{\} <br /> |
+
+
+#### DexStaticPassword
+
+
+
+DexStaticPassword defines a local user account in Dex's built-in password store.
+
+
+
+_Appears in:_
+- [DexSpec](#dexspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `email` _string_ | Email is the user's login email address. |  | Required: \{\} <br /> |
+| `hash` _string_ | Hash is the bcrypt hash of the user's password.<br />Generate with: htpasswd -nbBC 10 "" <password> \| tr -d ':\n' \| sed 's/$2y/$2a/' |  | Required: \{\} <br /> |
+| `username` _string_ | Username is the display name shown after login. |  | Optional: \{\} <br /> |
+| `userID` _string_ | UserID is a stable unique identifier for this user. |  | Optional: \{\} <br /> |
 
 
 #### GatewaySpec
@@ -175,7 +333,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `deployment` _[DeploymentSpec](#deploymentspec)_ | Deployment configures the Kubernetes deployment for the gateway pod. |  |  |
+| `deployment` _[DeploymentSpec](#deploymentspec)_ | Deployment configures the Kubernetes deployment for the gateway pod. |  | Optional: \{\} <br /> |
 
 
 #### IngressConfig
@@ -191,9 +349,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `enabled` _boolean_ | Enabled controls whether an Ingress is created for the gateway.<br />Defaults to true when cluster.spec.domain is set. |  |  |
-| `tls` _[IngressTLSConfig](#ingresstlsconfig)_ | TLS configuration for agent webhooks |  |  |
-| `className` _string_ | ClassName specifies the IngressClass to use (maps to spec.ingressClassName on the Ingress object). |  |  |
+| `enabled` _boolean_ | Enabled controls whether an external Ingress is created for the shared gateway.<br />Defaults to false — the gateway is reachable in-cluster via its Service. Set to<br />true to expose it externally at gateway.<spec.domain>. |  | Optional: \{\} <br /> |
+| `tls` _[IngressTLSConfig](#ingresstlsconfig)_ | TLS configuration for agent webhooks |  | Optional: \{\} <br /> |
+| `className` _string_ | ClassName specifies the IngressClass to use (maps to spec.ingressClassName on the Ingress object). |  | Optional: \{\} <br /> |
 
 
 #### IngressTLSConfig
@@ -209,9 +367,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `enabled` _boolean_ | Enabled controls whether TLS is enabled for webhooks | true |  |
-| `secretName` _string_ | SecretName is the name of the TLS secret (for manual cert management)<br />If empty, cert-manager will be used if available |  |  |
-| `issuerRef` _[CertIssuerReference](#certissuerreference)_ | IssuerRef references a cert-manager Issuer or ClusterIssuer |  |  |
+| `enabled` _boolean_ | Enabled controls whether TLS is enabled for webhooks.<br />Defaults to true; set to false to disable TLS. | true | Optional: \{\} <br /> |
+| `secretName` _string_ | SecretName is the name of an existing TLS secret (bring-your-own certificate).<br />When set, cert-manager integration is skipped and this secret is used directly. |  | Optional: \{\} <br /> |
 
 
 #### LanguageAgent
@@ -269,12 +426,78 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `image` _string_ | Image is the default container image for agents using this runtime.<br />Agents may override this. When a runtime is referenced, spec.image on the agent is optional. |  |  |
-| `ports` _[AgentPort](#agentport) array_ | Ports defines default ports for agents using this runtime.<br />Replace semantics: when the agent defines spec.ports, runtime ports are ignored entirely. |  |  |
-| `workspace` _[WorkspaceSpec](#workspacespec)_ | Workspace provides default size, storageClass, and mountPath for the agent's workspace.<br />Workspace storage is always provisioned; this presets its parameters.<br />Agents may override individual workspace fields. |  |  |
-| `deployment` _[DeploymentSpec](#deploymentspec)_ | Deployment provides default Kubernetes pod and container configuration.<br />Scalars (args, command, resources, probes, etc.) are used when the agent has none set.<br />Lists (initContainers, env, volumes, volumeMounts, envFrom) are runtime-first, agent-appended. |  |  |
-| `openclaw` _[OpenclawConfig](#openclawconfig)_ | Openclaw provides default openclaw credential configuration for agents using this runtime.<br />When set, the operator auto-generates OPENCLAW_GATEWAY_TOKEN per agent unless overridden. |  |  |
-| `opencode` _[OpencodeConfig](#opencodeconfig)_ | Opencode provides default opencode credential configuration for agents using this runtime.<br />When set, the operator auto-generates OPENCODE_SERVER_PASSWORD per agent unless overridden. |  |  |
+| `image` _string_ | Image is the default container image for agents using this runtime.<br />Agents may override this. When a runtime is referenced, spec.image on the agent is optional. |  | Optional: \{\} <br /> |
+| `ports` _[AgentPort](#agentport) array_ | Ports defines default ports for agents using this runtime.<br />Replace semantics: when the agent defines spec.ports, runtime ports are ignored entirely. |  | Optional: \{\} <br /> |
+| `workspace` _[WorkspaceSpec](#workspacespec)_ | Workspace provides default size, storageClass, and mountPath for the agent's workspace.<br />Workspace storage is always provisioned; this presets its parameters.<br />Agents may override individual workspace fields. |  | Optional: \{\} <br /> |
+| `deployment` _[DeploymentSpec](#deploymentspec)_ | Deployment provides default Kubernetes pod and container configuration.<br />Scalars (args, command, resources, probes, etc.) are used when the agent has none set.<br />Lists (initContainers, env, volumes, volumeMounts, envFrom) are runtime-first, agent-appended. |  | Optional: \{\} <br /> |
+| `credentials` _[CredentialSpec](#credentialspec) array_ | Credentials declares environment variables backed by Secret values that the<br />operator resolves and injects into agents using this runtime. Each entry is<br />auto-generated, set inline, or sourced from an existing Secret. Merged into the<br />agent's effective spec runtime-first; agent entries override by name. |  | Optional: \{\} <br /> |
+| `auth` _[RuntimeAuthSpec](#runtimeauthspec)_ | Auth gates whether agents using this runtime sit behind the cluster OIDC proxy.<br />Effective only when the cluster has auth enabled (which provisions the OIDC<br />infrastructure). The OIDC connection itself is configured cluster-wide. |  | Optional: \{\} <br /> |
+
+
+
+
+#### LanguageAgentSelfConfig
+
+
+
+LanguageAgentSelfConfig is submitted by an agent pod to request runtime modifications
+to its own LanguageAgent spec. The controller validates the request against the parent's
+spec.selfConfigure allowlist before patching.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `langop.io/v1alpha1` | | |
+| `kind` _string_ | `LanguageAgentSelfConfig` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[LanguageAgentSelfConfigSpec](#languageagentselfconfigspec)_ |  |  |  |
+| `status` _[LanguageAgentSelfConfigStatus](#languageagentselfconfigstatus)_ |  |  |  |
+
+
+#### LanguageAgentSelfConfigSpec
+
+
+
+LanguageAgentSelfConfigSpec defines the desired self-modification.
+
+
+
+_Appears in:_
+- [LanguageAgentSelfConfig](#languageagentselfconfig)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `instanceRef` _string_ | InstanceRef is the name of the LanguageAgent to modify. Must be in the same namespace. |  | MinLength: 1 <br />Required: \{\} <br /> |
+| `addTools` _string array_ | AddTools lists LanguageTool names to append to spec.tools on the parent agent. |  | Optional: \{\} <br /> |
+| `removeTools` _string array_ | RemoveTools lists LanguageTool names to remove from spec.tools on the parent agent. |  | Optional: \{\} <br /> |
+| `addModels` _string array_ | AddModels lists LanguageModel names to append to spec.models on the parent agent. |  | Optional: \{\} <br /> |
+| `removeModels` _string array_ | RemoveModels lists LanguageModel names to remove from spec.models on the parent agent. |  | Optional: \{\} <br /> |
+| `addEnvVars` _[SelfConfigEnvVar](#selfconfigenvvar) array_ | AddEnvVars lists plain-value environment variables to inject into the parent agent's<br />spec.deployment.env. Existing vars with the same name are overwritten.<br />SecretKeyRef and other value sources are not supported. |  | Optional: \{\} <br /> |
+| `updateInstructions` _string_ | UpdateInstructions, when non-empty, replaces spec.instructions on the parent agent. |  | Optional: \{\} <br /> |
+| `addRoleRules` _[PolicyRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#policyrule-v1-rbac) array_ | AddRoleRules lists RBAC policy rules to append to spec.deployment.roleRules on the<br />parent agent. Duplicate rules (identical APIGroups+Resources+Verbs) are de-duplicated. |  | Optional: \{\} <br /> |
+
+
+#### LanguageAgentSelfConfigStatus
+
+
+
+LanguageAgentSelfConfigStatus reflects the observed state of a self-config request.
+
+
+
+_Appears in:_
+- [LanguageAgentSelfConfig](#languageagentselfconfig)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `phase` _[SelfConfigPhase](#selfconfigphase)_ | Phase is the current processing state. |  | Enum: [Pending Applied Failed Denied] <br />Optional: \{\} <br /> |
+| `message` _string_ | Message provides a human-readable explanation of the current phase. |  | Optional: \{\} <br /> |
+| `completionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | CompletionTime is set when the request reaches a terminal phase (Applied, Failed, Denied).<br />The CR is automatically deleted 1 hour after this time. |  | Optional: \{\} <br /> |
+
+
 
 
 #### LanguageAgentSpec
@@ -290,18 +513,20 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `runtime` _string_ | Runtime is the name of a LanguageAgentRuntime that provides preset configuration<br />(image, port, init containers, env vars, probes, etc.).<br />When set, spec.image is optional; the runtime provides a default. |  |  |
-| `image` _string_ | Image is the container image to run for this agent.<br />Required unless spec.runtime is set (the runtime provides a default image). |  | Pattern: `^([a-z0-9]+([._-][a-z0-9]+)*\/)*[a-z0-9]+([._-][a-z0-9]+)*(:[a-z0-9]+([._-][a-z0-9]+)*)?$` <br /> |
-| `models` _[ModelReference](#modelreference) array_ | Models is a list of LanguageModel references this agent can use |  |  |
-| `tools` _[ToolReference](#toolreference) array_ | Tools is a list of LanguageTool references available to this agent |  |  |
-| `persona` _string_ | Persona is the name of a LanguagePersona this agent uses |  |  |
-| `instructions` _string_ | Instructions provides system instructions for the agent.<br />Delivered as the top-level "instructions" field in /etc/agent/config.yaml. |  |  |
-| `workspace` _[WorkspaceSpec](#workspacespec)_ | Workspace defines persistent storage for the agent |  |  |
-| `networkPolicies` _[AgentNetworkPolicies](#agentnetworkpolicies)_ | NetworkPolicies defines ingress and egress rules for this agent.<br />Rules mirror the native Kubernetes NetworkPolicy shape. |  |  |
-| `ports` _[AgentPort](#agentport) array_ | Ports defines all network ports this agent exposes.<br />At most one entry should have expose: true (the ingress target);<br />if none are marked, the first port is used for ingress routing.<br />Defaults to a single HTTP port on 8080 when not set. |  |  |
-| `deployment` _[DeploymentSpec](#deploymentspec)_ | Deployment groups Kubernetes-specific pod and container configuration. |  |  |
-| `opencode` _[OpencodeConfig](#opencodeconfig)_ | Opencode holds configuration specific to the opencode runtime.<br />Only effective when spec.runtime is "opencode". |  |  |
-| `openclaw` _[OpenclawConfig](#openclawconfig)_ | Openclaw holds configuration specific to the openclaw runtime.<br />Only effective when spec.runtime is "openclaw". |  |  |
+| `runtime` _string_ | Runtime is the name of a LanguageAgentRuntime that provides preset configuration<br />(image, port, init containers, env vars, probes, etc.).<br />When set, spec.image is optional; the runtime provides a default. |  | Optional: \{\} <br /> |
+| `image` _string_ | Image is the container image to run for this agent.<br />Required unless spec.runtime is set (the runtime provides a default image). |  | Pattern: `^([a-z0-9]+([._-][a-z0-9]+)*\/)*[a-z0-9]+([._-][a-z0-9]+)*(:[a-z0-9]+([._-][a-z0-9]+)*)?$` <br />Optional: \{\} <br /> |
+| `models` _[ModelReference](#modelreference) array_ | Models is a list of LanguageModel references this agent can use |  | Optional: \{\} <br /> |
+| `tools` _[ToolReference](#toolreference) array_ | Tools is a list of LanguageTool references available to this agent |  | Optional: \{\} <br /> |
+| `persona` _string_ | Persona is the name of a LanguagePersona this agent uses |  | Optional: \{\} <br /> |
+| `instructions` _string_ | Instructions provides system instructions for the agent.<br />Delivered as the top-level "instructions" field in /etc/agent/config.yaml. |  | Optional: \{\} <br /> |
+| `workspace` _[WorkspaceSpec](#workspacespec)_ | Workspace defines persistent storage for the agent |  | Optional: \{\} <br /> |
+| `repository` _[RepositorySpec](#repositoryspec)_ | Repository declares a git repository to clone into the agent's workspace.<br />When set, the operator ensures a workspace PVC is provisioned (defaulting it on<br />if not explicitly configured) so the clone has somewhere to land. |  | Optional: \{\} <br /> |
+| `networkPolicies` _[AgentNetworkPolicies](#agentnetworkpolicies)_ | NetworkPolicies defines ingress and egress rules for this agent.<br />Rules mirror the native Kubernetes NetworkPolicy shape. |  | Optional: \{\} <br /> |
+| `ports` _[AgentPort](#agentport) array_ | Ports defines all network ports this agent exposes.<br />At most one entry should have expose: true (the ingress target);<br />if none are marked, the first port is used for ingress routing.<br />Defaults to a single HTTP port on 8080 when not set. |  | Optional: \{\} <br /> |
+| `deployment` _[DeploymentSpec](#deploymentspec)_ | Deployment groups Kubernetes-specific pod and container configuration. |  | Optional: \{\} <br /> |
+| `credentials` _[CredentialSpec](#credentialspec) array_ | Credentials declares environment variables backed by Secret values that the<br />operator resolves and injects into the agent container. Typically supplied by<br />the referenced LanguageAgentRuntime; agents may add or override entries by name. |  | Optional: \{\} <br /> |
+| `selfConfigure` _[SelfConfigureSpec](#selfconfigurespec)_ | SelfConfigure controls whether this agent may submit LanguageAgentSelfConfig<br />requests to modify its own spec at runtime. When enabled, the operator grants<br />the agent's ServiceAccount permission to create LanguageAgentSelfConfig resources. |  | Optional: \{\} <br /> |
+| `monitoring` _[AgentMonitoringSpec](#agentmonitoringspec)_ | Monitoring configures Prometheus Operator integration for this agent.<br />When set, the operator creates a ServiceMonitor and/or PrometheusRule resource.<br />Requires prometheus-operator to be installed in the cluster; silently skipped otherwise. |  | Optional: \{\} <br /> |
 
 
 #### LanguageAgentStatus
@@ -317,13 +542,15 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `phase` _string_ | Phase represents the current phase of the agent |  | Enum: [Pending Running Failed] <br /> |
-| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ | Conditions represent the latest available observations of the agent's state |  |  |
-| `activeReplicas` _integer_ | ActiveReplicas is the number of agent pods currently running |  |  |
-| `readyReplicas` _integer_ | ReadyReplicas is the number of agent pods ready |  |  |
-| `uuid` _string_ | UUID is a unique identifier for this agent instance<br />Not used for webhook routing; webhooks are routed via agent name (e.g., <agent-name>.domain.com) |  |  |
-| `webhookURLs` _string array_ | WebhookURLs contains the URLs where this agent can receive webhooks |  |  |
-| `observedGeneration` _integer_ | ObservedGeneration is the most recent generation observed by the controller.<br />It corresponds to the metadata.generation of the LanguageAgent at the time<br />the controller last processed it. Watchers can use this to detect when the<br />status reflects a stale version of the spec. |  |  |
+| `phase` _string_ | Phase represents the current phase of the agent |  | Enum: [Pending Running Failed Updating Degraded] <br />Optional: \{\} <br /> |
+| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ | Conditions represent the latest available observations of the agent's state |  | Optional: \{\} <br /> |
+| `activeReplicas` _integer_ | ActiveReplicas is the number of agent pods currently running |  | Optional: \{\} <br /> |
+| `readyReplicas` _integer_ | ReadyReplicas is the number of agent pods ready |  | Optional: \{\} <br /> |
+| `uuid` _string_ | UUID is a unique identifier for this agent instance<br />Not used for webhook routing; webhooks are routed via agent name (e.g., <agent-name>.domain.com) |  | Optional: \{\} <br /> |
+| `webhookURLs` _string array_ | WebhookURLs contains the URLs where this agent can receive webhooks |  | Optional: \{\} <br /> |
+| `observedGeneration` _integer_ | ObservedGeneration is the most recent generation observed by the controller.<br />It corresponds to the metadata.generation of the LanguageAgent at the time<br />the controller last processed it. Watchers can use this to detect when the<br />status reflects a stale version of the spec. |  | Optional: \{\} <br /> |
+| `workspacePVCName` _string_ | WorkspacePVCName is the name of the retained workspace PVC after agent deletion.<br />Only set when spec.workspace.retain is true. |  | Optional: \{\} <br /> |
+| `managedResources` _[ManagedResource](#managedresource) array_ | ManagedResources is the inventory of Kubernetes resources created and owned<br />by this controller on behalf of this LanguageAgent.<br />The list is replaced atomically on every successful reconcile. |  | Optional: \{\} <br /> |
 
 
 
@@ -360,11 +587,12 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `domain` _string_ | Domain is the base domain for the cluster and agent webhook routing<br />The domain itself serves as the cluster dashboard/UI endpoint<br />Agent webhooks will be accessible at <agent-name>.<domain><br />Example: "ai.theryans.io" results in webhooks like "my-agent.ai.theryans.io" |  |  |
-| `ingress` _[IngressConfig](#ingressconfig)_ | Ingress defines ingress configuration for the cluster |  |  |
-| `networkPolicies` _[AgentNetworkPolicies](#agentnetworkpolicies)_ | NetworkPolicies defines ingress and egress rules for agents in this cluster.<br />Rules mirror the native Kubernetes NetworkPolicy shape. |  |  |
-| `gateway` _[GatewaySpec](#gatewayspec)_ | Gateway configures the shared LiteLLM gateway deployed per cluster |  |  |
-| `capacity` _[ClusterCapacitySpec](#clustercapacityspec)_ | Capacity declares hard limits enforced via a ResourceQuota in the cluster's namespace.<br />When set, the controller creates a ResourceQuota named "langop-quota".<br />When unset, any existing "langop-quota" is deleted. |  |  |
+| `domain` _string_ | Domain is the base domain for the cluster and agent webhook routing.<br />Agent webhooks will be accessible at <agent-name>.<domain>.<br />Example: "ai.theryans.io" results in webhooks like "my-agent.ai.theryans.io" |  | Optional: \{\} <br /> |
+| `ingress` _[IngressConfig](#ingressconfig)_ | Ingress defines ingress configuration for the cluster |  | Optional: \{\} <br /> |
+| `networkPolicies` _[AgentNetworkPolicies](#agentnetworkpolicies)_ | NetworkPolicies defines ingress and egress rules for agents in this cluster.<br />Rules mirror the native Kubernetes NetworkPolicy shape. |  | Optional: \{\} <br /> |
+| `gateway` _[GatewaySpec](#gatewayspec)_ | Gateway configures the shared LiteLLM gateway deployed per cluster |  | Optional: \{\} <br /> |
+| `capacity` _[ClusterCapacitySpec](#clustercapacityspec)_ | Capacity declares hard limits enforced via a ResourceQuota in the cluster's namespace.<br />When set, the controller creates a ResourceQuota named "langop-quota".<br />When unset, any existing "langop-quota" is deleted. |  | Optional: \{\} <br /> |
+| `auth` _[ClusterAuthSpec](#clusterauthspec)_ | Auth configures OIDC authentication for agent ingress routes in this cluster.<br />When enabled, a Dex OIDC provider is deployed alongside the gateway and each<br />LanguageAgent with auth enabled gets an oauth2-proxy in front of its ingress. |  | Optional: \{\} <br /> |
 
 
 #### LanguageClusterStatus
@@ -381,11 +609,14 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `phase` _string_ | Phase of the cluster |  | Enum: [Pending Ready Failed] <br /> |
-| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ |  |  |  |
-| `gatewayEndpoint` _string_ | GatewayEndpoint is the in-cluster URL for the shared LiteLLM gateway |  |  |
-| `gatewayReady` _boolean_ | GatewayReady indicates whether the shared gateway Deployment is available.<br />Pointer distinguishes "not yet reconciled" (nil) from "known not ready" (false). |  |  |
-| `capacity` _[ClusterCapacityStatus](#clustercapacitystatus)_ | Capacity reports observed resource usage in this cluster's namespace. |  |  |
-| `observedGeneration` _integer_ | ObservedGeneration is the most recent generation observed by the controller.<br />It corresponds to the metadata.generation of the LanguageCluster at the time<br />the controller last processed it. Watchers can use this to detect when the<br />status reflects a stale version of the spec. |  |  |
+| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ |  |  | Optional: \{\} <br /> |
+| `gatewayEndpoint` _string_ | GatewayEndpoint is the in-cluster URL for the shared LiteLLM gateway |  | Optional: \{\} <br /> |
+| `gatewayReady` _boolean_ | GatewayReady indicates whether the shared gateway Deployment is available.<br />Pointer distinguishes "not yet reconciled" (nil) from "known not ready" (false). |  | Optional: \{\} <br /> |
+| `capacity` _[ClusterCapacityStatus](#clustercapacitystatus)_ | Capacity reports observed resource usage in this cluster's namespace. |  | Optional: \{\} <br /> |
+| `observedGeneration` _integer_ | ObservedGeneration is the most recent generation observed by the controller.<br />It corresponds to the metadata.generation of the LanguageCluster at the time<br />the controller last processed it. Watchers can use this to detect when the<br />status reflects a stale version of the spec. |  | Optional: \{\} <br /> |
+| `managedResources` _[ManagedResource](#managedresource) array_ | ManagedResources is the inventory of Kubernetes resources created and owned<br />by this controller on behalf of this LanguageCluster.<br />The list is replaced atomically on every successful reconcile. |  | Optional: \{\} <br /> |
+
+
 
 
 #### LanguageModel
@@ -422,10 +653,10 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `provider` _string_ | Provider specifies the LLM provider type |  | Enum: [openai anthropic openai-compatible azure bedrock vertex custom] <br />Required: \{\} <br /> |
 | `modelName` _string_ | ModelName is the specific model identifier (e.g., "gpt-4", "claude-3-opus") |  | MinLength: 1 <br />Required: \{\} <br /> |
-| `endpoint` _string_ | Endpoint is the API endpoint URL (required for openai-compatible, azure, custom) |  |  |
-| `apiKeySecretRef` _[SecretReference](#secretreference)_ | APIKeySecretRef references a secret containing the API key |  |  |
-| `rateLimits` _[RateLimitSpec](#ratelimitspec)_ | RateLimits defines rate limiting configuration |  |  |
-| `timeout` _string_ | Timeout specifies request timeout duration (e.g., "5m", "30s") | 5m | Pattern: `^[0-9]+(ns\|us\|µs\|ms\|s\|m\|h)$` <br /> |
+| `endpoint` _string_ | Endpoint is the API endpoint URL (required for openai-compatible, azure, custom) |  | Optional: \{\} <br /> |
+| `apiKeySecretRef` _[SecretReference](#secretreference)_ | APIKeySecretRef references a secret containing the API key |  | Optional: \{\} <br /> |
+| `rateLimits` _[RateLimitSpec](#ratelimitspec)_ | RateLimits defines rate limiting configuration |  | Optional: \{\} <br /> |
+| `timeout` _string_ | Timeout specifies request timeout duration (e.g., "5m", "30s") | 5m | Pattern: `^[0-9]+(ns\|us\|µs\|ms\|s\|m\|h)$` <br />Optional: \{\} <br /> |
 
 
 #### LanguageModelStatus
@@ -441,10 +672,10 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `observedGeneration` _integer_ | ObservedGeneration reflects the generation of the most recently observed LanguageModel |  |  |
-| `phase` _string_ | Phase represents the current phase of the model |  | Enum: [Ready] <br /> |
-| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ | Conditions represent the latest available observations of the model's state |  |  |
-| `message` _string_ | Message provides human-readable details about the current state |  |  |
+| `observedGeneration` _integer_ | ObservedGeneration reflects the generation of the most recently observed LanguageModel |  | Optional: \{\} <br /> |
+| `phase` _string_ | Phase represents the current phase of the model (Pending, Ready, Failed) |  | Enum: [Pending Ready Failed] <br />Optional: \{\} <br /> |
+| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ | Conditions represent the latest available observations of the model's state |  | Optional: \{\} <br /> |
+| `message` _string_ | Message provides human-readable details about the current state |  | Optional: \{\} <br /> |
 
 
 
@@ -481,9 +712,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `tone` _string_ | Tone describes the agent's communication style<br />e.g. "professional", "concise and direct", "warm and encouraging" |  |  |
-| `personality` _string_ | Personality describes the agent's character and behavioural traits<br />e.g. "curious and methodical, always explains reasoning step by step" |  |  |
-| `expertise` _string_ | Expertise describes the agent's domain knowledge and skills<br />e.g. "senior software engineer specialising in distributed systems and Go" |  |  |
+| `tone` _string_ | Tone describes the agent's communication style<br />e.g. "professional", "concise and direct", "warm and encouraging" |  | Optional: \{\} <br /> |
+| `personality` _string_ | Personality describes the agent's character and behavioural traits<br />e.g. "curious and methodical, always explains reasoning step by step" |  | Optional: \{\} <br /> |
+| `expertise` _string_ | Expertise describes the agent's domain knowledge and skills<br />e.g. "senior software engineer specialising in distributed systems and Go" |  | Optional: \{\} <br /> |
 
 
 #### LanguagePersonaStatus
@@ -499,9 +730,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `observedGeneration` _integer_ | ObservedGeneration reflects the generation of the most recently observed LanguagePersona |  |  |
-| `phase` _string_ | Phase represents the current phase |  | Enum: [Ready] <br /> |
-| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ | Conditions represent the latest available observations of the persona's state |  |  |
+| `observedGeneration` _integer_ | ObservedGeneration reflects the generation of the most recently observed LanguagePersona |  | Optional: \{\} <br /> |
+| `phase` _string_ | Phase represents the current phase (Pending, Ready, Failed) |  | Enum: [Pending Ready Failed] <br />Optional: \{\} <br /> |
+| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ | Conditions represent the latest available observations of the persona's state |  | Optional: \{\} <br /> |
 
 
 
@@ -538,12 +769,14 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `image` _string_ | Image is the container image to run for this tool |  | MinLength: 1 <br />Required: \{\} <br /> |
+| `image` _string_ | Image is the container image to run for this tool. For transport=stdio it is ignored —<br />the operator injects the MCP bridge image instead — and may be omitted (the defaulting<br />webhook fills it). |  | MinLength: 1 <br />Required: \{\} <br /> |
 | `type` _string_ | Type specifies the tool protocol type. Only "mcp" is currently implemented. | mcp | Enum: [mcp] <br /> |
-| `deploymentMode` _string_ | DeploymentMode specifies how this tool should be deployed<br />- "service": Deployed as a standalone Deployment+Service (default, shared across agents)<br />- "sidecar": Deployed as a sidecar container in each agent pod (dedicated, with workspace access) | service | Enum: [service sidecar] <br /> |
+| `transport` _string_ | Transport selects how the operator exposes this tool's MCP endpoint.<br />- "streamable-http" (default): spec.image already serves Streamable HTTP at /mcp.<br />- "sse": spec.image already serves the (legacy) MCP HTTP+SSE transport.<br />- "stdio": the user supplies a stdio MCP command in spec.stdio; the operator injects a<br />  pinned, persistent stdio→Streamable-HTTP bridge that serves /mcp and /health on spec.port. | streamable-http | Enum: [streamable-http sse stdio] <br />Optional: \{\} <br /> |
+| `stdio` _[StdioServerSpec](#stdioserverspec)_ | Stdio configures the stdio MCP server when transport=stdio. Required for that transport,<br />ignored otherwise. |  | Optional: \{\} <br /> |
+| `deploymentMode` _string_ | DeploymentMode specifies how this tool should be deployed<br />- "service": Deployed as a standalone Deployment+Service (default, shared across agents)<br />- "sidecar": Deployed as a sidecar container in each agent pod (dedicated, with workspace access) | service | Enum: [service sidecar] <br />Optional: \{\} <br /> |
 | `port` _integer_ | Port is the port the tool listens on | 8080 | Maximum: 65535 <br />Minimum: 1 <br /> |
-| `deployment` _[DeploymentSpec](#deploymentspec)_ | Deployment groups Kubernetes-specific pod and container configuration. |  |  |
-| `networkPolicies` _[AgentNetworkPolicies](#agentnetworkpolicies)_ | NetworkPolicies defines ingress and egress rules for this tool.<br />Rules mirror the native Kubernetes NetworkPolicy shape. |  |  |
+| `deployment` _[DeploymentSpec](#deploymentspec)_ | Deployment groups Kubernetes-specific pod and container configuration. |  | Optional: \{\} <br /> |
+| `networkPolicies` _[AgentNetworkPolicies](#agentnetworkpolicies)_ | NetworkPolicies defines ingress and egress rules for this tool.<br />Rules mirror the native Kubernetes NetworkPolicy shape. |  | Optional: \{\} <br /> |
 
 
 #### LanguageToolStatus
@@ -559,17 +792,39 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `observedGeneration` _integer_ | ObservedGeneration reflects the generation of the most recently observed LanguageTool |  |  |
-| `phase` _string_ | Phase represents the current phase of the tool (Pending, Running, Failed, Updating) |  | Enum: [Pending Running Failed Updating] <br /> |
-| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ | Conditions represent the latest available observations of the tool's state |  |  |
-| `endpoint` _string_ | Endpoint is the service endpoint where the tool is accessible |  |  |
-| `toolSchemas` _[ToolSchema](#toolschema) array_ | ToolSchemas contains the complete MCP tool schemas discovered from this service |  |  |
-| `readyReplicas` _integer_ | ReadyReplicas is the number of pods ready and passing health checks |  |  |
-| `availableReplicas` _integer_ | AvailableReplicas is the number of pods targeted by this LanguageTool with at least one available condition |  |  |
-| `updatedReplicas` _integer_ | UpdatedReplicas is the number of pods targeted by this LanguageTool that have the desired spec |  |  |
-| `unavailableReplicas` _integer_ | UnavailableReplicas is the number of pods targeted by this LanguageTool that are unavailable |  |  |
+| `observedGeneration` _integer_ | ObservedGeneration reflects the generation of the most recently observed LanguageTool |  | Optional: \{\} <br /> |
+| `phase` _string_ | Phase represents the current phase of the tool (Pending, Running, Failed, Updating, Degraded) |  | Enum: [Pending Running Failed Updating Degraded] <br />Optional: \{\} <br /> |
+| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ | Conditions represent the latest available observations of the tool's state |  | Optional: \{\} <br /> |
+| `endpoint` _string_ | Endpoint is the service endpoint where the tool is accessible |  | Optional: \{\} <br /> |
+| `toolSchemas` _[ToolSchema](#toolschema) array_ | ToolSchemas contains the complete MCP tool schemas discovered from this service |  | Optional: \{\} <br /> |
+| `readyReplicas` _integer_ | ReadyReplicas is the number of pods ready and passing health checks |  | Optional: \{\} <br /> |
+| `availableReplicas` _integer_ | AvailableReplicas is the number of pods targeted by this LanguageTool with at least one available condition |  | Optional: \{\} <br /> |
+| `updatedReplicas` _integer_ | UpdatedReplicas is the number of pods targeted by this LanguageTool that have the desired spec |  | Optional: \{\} <br /> |
+| `unavailableReplicas` _integer_ | UnavailableReplicas is the number of pods targeted by this LanguageTool that are unavailable |  | Optional: \{\} <br /> |
 
 
+
+
+#### ManagedResource
+
+
+
+ManagedResource describes a single Kubernetes resource created and owned
+by this operator on behalf of a LanguageAgent or LanguageCluster.
+The combination of Group+Kind+Namespace+Name uniquely identifies the resource.
+
+
+
+_Appears in:_
+- [LanguageAgentStatus](#languageagentstatus)
+- [LanguageClusterStatus](#languageclusterstatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `group` _string_ | Group is the API group of the resource.<br />Empty string means the core API group (e.g. ConfigMap, Service, PersistentVolumeClaim). |  | Optional: \{\} <br /> |
+| `kind` _string_ | Kind is the Kubernetes resource kind (e.g. "Deployment", "ConfigMap"). |  |  |
+| `name` _string_ | Name is the name of the resource. |  |  |
+| `namespace` _string_ | Namespace is the namespace of the resource.<br />Empty for cluster-scoped resources (e.g. Namespace). |  | Optional: \{\} <br /> |
 
 
 #### ModelReference
@@ -586,8 +841,8 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `name` _string_ | Name is the name of the LanguageModel |  | MaxLength: 63 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` <br />Required: \{\} <br /> |
-| `role` _string_ | Role defines the purpose of this model — a hint for the agent runtime for model selection<br />(e.g. prefer role=primary for general calls, role=reasoning for chain-of-thought).<br />The operator does not enforce routing by role; it is surfaced in the agent config (agent.json). | primary | Enum: [primary fallback reasoning tool-calling summarization] <br /> |
-| `priority` _integer_ | Priority for model selection — a hint for the agent runtime (lower value = higher priority).<br />The operator does not enforce priority; it is surfaced in the agent config (agent.json). |  |  |
+| `role` _string_ | Role defines the purpose of this model — a hint for the agent runtime for model selection<br />(e.g. prefer role=primary for general calls, role=reasoning for chain-of-thought).<br />The operator does not enforce routing by role; it is surfaced in the agent config (agent.json). | primary | Enum: [primary fallback reasoning tool-calling summarization] <br />Optional: \{\} <br /> |
+| `priority` _integer_ | Priority for model selection — a hint for the agent runtime (lower value = higher priority).<br />The operator does not enforce priority; it is surfaced in the agent config (agent.json). |  | Optional: \{\} <br /> |
 
 
 #### NetworkEgressRule
@@ -604,8 +859,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `to` _[NetworkPeer](#networkpeer) array_ | To lists the destinations this workload is allowed to reach. |  |  |
-| `ports` _[NetworkPort](#networkport) array_ | Ports lists the destination ports to allow. |  |  |
+| `to` _[NetworkPeer](#networkpeer) array_ | To lists the destinations this workload is allowed to reach. |  | Optional: \{\} <br /> |
+| `ports` _[NetworkPort](#networkport) array_ | Ports lists the destination ports to allow. |  | Optional: \{\} <br /> |
 
 
 #### NetworkIngressRule
@@ -622,8 +877,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `from` _[NetworkPeer](#networkpeer) array_ | From lists the sources allowed to send traffic to this workload. |  |  |
-| `ports` _[NetworkPort](#networkport) array_ | Ports lists the ports on which to allow incoming traffic. |  |  |
+| `from` _[NetworkPeer](#networkpeer) array_ | From lists the sources allowed to send traffic to this workload. |  | Optional: \{\} <br /> |
+| `ports` _[NetworkPort](#networkport) array_ | Ports lists the ports on which to allow incoming traffic. |  | Optional: \{\} <br /> |
 
 
 #### NetworkPeer
@@ -640,12 +895,12 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `group` _string_ | Group selects pods with matching langop.io/group label<br />Used to allow communication with specific labeled resources |  |  |
-| `cidr` _string_ | CIDR block |  |  |
-| `dns` _string array_ | DNS names (supports wildcards with *)<br />Examples: "api.openai.com", "*.googleapis.com" |  |  |
-| `service` _[ServiceReference](#servicereference)_ | Kubernetes service reference |  |  |
-| `namespaceSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta)_ | Namespace selector (for cross-namespace rules) |  |  |
-| `podSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta)_ | Pod selector (within namespace) |  |  |
+| `group` _string_ | Group selects pods with matching langop.io/group label<br />Used to allow communication with specific labeled resources |  | Optional: \{\} <br /> |
+| `cidr` _string_ | CIDR block |  | Optional: \{\} <br /> |
+| `dns` _string array_ | DNS names (supports wildcards with *)<br />Examples: "api.openai.com", "*.googleapis.com" |  | Optional: \{\} <br /> |
+| `service` _[ServiceReference](#servicereference)_ | Kubernetes service reference |  | Optional: \{\} <br /> |
+| `namespaceSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta)_ | Namespace selector (for cross-namespace rules) |  | Optional: \{\} <br /> |
+| `podSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta)_ | Pod selector (within namespace) |  | Optional: \{\} <br /> |
 
 
 #### NetworkPort
@@ -662,49 +917,47 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `protocol` _string_ | Protocol (TCP, UDP, SCTP) | TCP | Enum: [TCP UDP SCTP] <br /> |
+| `protocol` _string_ | Protocol (TCP, UDP, SCTP) | TCP | Enum: [TCP UDP SCTP] <br />Optional: \{\} <br /> |
 | `port` _integer_ | Port number |  | Maximum: 65535 <br />Minimum: 1 <br /> |
 
 
-#### OpenclawConfig
+#### PrometheusAlertingRule
 
 
 
-OpenclawConfig holds configuration specific to the openclaw runtime.
-Effective only when spec.runtime is "openclaw".
-
-
-
-_Appears in:_
-- [LanguageAgentRuntimeSpec](#languageagentruntimespec)
-- [LanguageAgentSpec](#languageagentspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `enabled` _boolean_ | Enabled activates openclaw credential management for this agent.<br />Set to true in a LanguageAgentRuntime to trigger auto-generation of OPENCLAW_GATEWAY_TOKEN<br />without requiring any explicit config on the LanguageAgent. |  |  |
-| `token` _string_ | Token is the gateway authentication token (inline).<br />The operator creates a managed Secret and injects it via envFrom.<br />Mutually exclusive with TokenRef. |  |  |
-| `tokenRef` _[RuntimeSecretRef](#runtimesecretref)_ | TokenRef references a Secret whose keys are injected via envFrom.<br />The Secret must contain OPENCLAW_GATEWAY_TOKEN.<br />Mutually exclusive with Token. |  |  |
-
-
-#### OpencodeConfig
-
-
-
-OpencodeConfig holds configuration specific to the opencode runtime.
-Effective only when spec.runtime is "opencode".
+PrometheusAlertingRule defines a single Prometheus alerting or recording rule.
 
 
 
 _Appears in:_
-- [LanguageAgentRuntimeSpec](#languageagentruntimespec)
-- [LanguageAgentSpec](#languageagentspec)
+- [PrometheusRuleGroup](#prometheusrulegroup)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `enabled` _boolean_ | Enabled activates opencode credential management for this agent.<br />Set to true in a LanguageAgentRuntime to trigger auto-generation of credentials<br />without requiring any explicit config on the LanguageAgent. |  |  |
-| `username` _string_ | Username for HTTP Basic Auth. Defaults to "opencode" if not set.<br />Sets OPENCODE_SERVER_USERNAME in the agent container. |  |  |
-| `password` _string_ | Password is the HTTP Basic Auth password (inline).<br />The operator creates a managed Secret and injects it via envFrom.<br />Mutually exclusive with PasswordRef. |  |  |
-| `passwordRef` _[RuntimeSecretRef](#runtimesecretref)_ | PasswordRef references a Secret whose keys are injected via envFrom.<br />The Secret must contain OPENCODE_SERVER_PASSWORD (and optionally OPENCODE_SERVER_USERNAME).<br />Mutually exclusive with Password. |  |  |
+| `alert` _string_ | Alert is the alert name. Leave empty for recording rules. |  | Optional: \{\} <br /> |
+| `record` _string_ | Record is the output metric name for recording rules. Leave empty for alerting rules. |  | Optional: \{\} <br /> |
+| `expr` _string_ | Expr is the PromQL expression evaluated at each evaluation cycle. |  | Required: \{\} <br /> |
+| `for` _string_ | For is the duration the condition must be true before the alert fires.<br />Only valid for alerting rules. |  | Optional: \{\} <br /> |
+| `labels` _object (keys:string, values:string)_ | Labels are labels attached to the alert or recording rule. |  | Optional: \{\} <br /> |
+| `annotations` _object (keys:string, values:string)_ | Annotations are annotations attached to the alert. Only valid for alerting rules. |  | Optional: \{\} <br /> |
+
+
+#### PrometheusRuleGroup
+
+
+
+PrometheusRuleGroup defines a group of Prometheus alerting or recording rules.
+
+
+
+_Appears in:_
+- [AgentMonitoringSpec](#agentmonitoringspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the rule group. |  | Required: \{\} <br /> |
+| `interval` _string_ | Interval is the evaluation interval for this group. Uses the Prometheus default when omitted. |  | Optional: \{\} <br /> |
+| `rules` _[PrometheusAlertingRule](#prometheusalertingrule) array_ | Rules is the list of alerting or recording rules in this group. |  | MinItems: 1 <br /> |
 
 
 #### RateLimitSpec
@@ -720,8 +973,46 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `requestsPerMinute` _integer_ | RequestsPerMinute limits requests per minute |  |  |
-| `tokensPerMinute` _integer_ | TokensPerMinute limits tokens per minute |  |  |
+| `requestsPerMinute` _integer_ | RequestsPerMinute limits requests per minute |  | Optional: \{\} <br /> |
+| `tokensPerMinute` _integer_ | TokensPerMinute limits tokens per minute |  | Optional: \{\} <br /> |
+
+
+#### RepositorySpec
+
+
+
+RepositorySpec declares a git repository to clone into the agent's workspace.
+The clone is performed by the operator at pod startup; this type defines only the
+desired source. Follows the WorkspaceSpec/CredentialSpec conventions.
+
+
+
+_Appears in:_
+- [LanguageAgentSpec](#languageagentspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `url` _string_ | URL is the git repository to clone (https://... or git@... SSH). |  | Required: \{\} <br /> |
+| `ref` _string_ | Ref is the branch, tag, or commit SHA to check out. Defaults to the default branch. |  | Optional: \{\} <br /> |
+| `path` _string_ | Path is the subdirectory under the workspace mountPath to clone into.<br />Defaults to the repository name derived from the URL. Must be a relative path<br />(no leading "/", no ".." segments). |  | Optional: \{\} <br /> |
+| `depth` _integer_ | Depth, when > 0, performs a shallow clone with this history depth. |  | Minimum: 0 <br />Optional: \{\} <br /> |
+| `secretRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ | SecretRef references a Secret with git credentials for private repos.<br />Recognized keys: `token` or `username`+`password` (HTTPS), `ssh-privatekey` (SSH). |  | Optional: \{\} <br /> |
+
+
+#### RuntimeAuthSpec
+
+
+
+RuntimeAuthSpec gates OIDC authentication for agents using a runtime.
+
+
+
+_Appears in:_
+- [LanguageAgentRuntimeSpec](#languageagentruntimespec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `enabled` _boolean_ | Enabled puts agents using this runtime behind the cluster OIDC proxy.<br />Has no effect unless the cluster has auth enabled. |  | Optional: \{\} <br /> |
 
 
 #### RuntimeSecretRef
@@ -734,8 +1025,7 @@ All keys in the Secret are injected as env vars via envFrom.
 
 
 _Appears in:_
-- [OpenclawConfig](#openclawconfig)
-- [OpencodeConfig](#opencodeconfig)
+- [CredentialSpec](#credentialspec)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -751,13 +1041,90 @@ SecretReference references a Kubernetes Secret
 
 
 _Appears in:_
+- [ClusterOIDCSpec](#clusteroidcspec)
 - [LanguageModelSpec](#languagemodelspec)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `name` _string_ | Name is the name of the secret |  | Required: \{\} <br /> |
-| `namespace` _string_ | Namespace is the namespace of the secret (defaults to same namespace as LanguageModel) |  |  |
-| `key` _string_ | Key is the key within the secret containing the value | api-key |  |
+| `key` _string_ | Key is the key within the secret containing the value | api-key | Optional: \{\} <br /> |
+
+
+#### SelfConfigAction
+
+_Underlying type:_ _string_
+
+SelfConfigAction is a category of self-modification an agent may request.
+
+_Validation:_
+- Enum: [tools models envVars instructions roleRules]
+
+_Appears in:_
+- [SelfConfigureSpec](#selfconfigurespec)
+
+| Field | Description |
+| --- | --- |
+| `tools` | SelfConfigActionTools allows the agent to add or remove tool references.<br /> |
+| `models` | SelfConfigActionModels allows the agent to add or remove model references.<br /> |
+| `envVars` | SelfConfigActionEnvVars allows the agent to inject plain-value environment variables.<br /> |
+| `instructions` | SelfConfigActionInstructions allows the agent to replace its system instructions.<br /> |
+| `roleRules` | SelfConfigActionRoleRules allows the agent to append RBAC policy rules to its Role.<br /> |
+
+
+#### SelfConfigEnvVar
+
+
+
+SelfConfigEnvVar is a plain-value environment variable injected by a self-config request.
+SecretKeyRef and other value sources are intentionally not supported.
+
+
+
+_Appears in:_
+- [LanguageAgentSelfConfigSpec](#languageagentselfconfigspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the environment variable. |  | MinLength: 1 <br />Required: \{\} <br /> |
+| `value` _string_ | Value is the literal string value of the variable. |  | Required: \{\} <br /> |
+
+
+#### SelfConfigPhase
+
+_Underlying type:_ _string_
+
+SelfConfigPhase reflects the current processing state of a LanguageAgentSelfConfig.
+
+_Validation:_
+- Enum: [Pending Applied Failed Denied]
+
+_Appears in:_
+- [LanguageAgentSelfConfigStatus](#languageagentselfconfigstatus)
+
+| Field | Description |
+| --- | --- |
+| `Pending` | SelfConfigPhasePending means the request has not yet been processed.<br /> |
+| `Applied` | SelfConfigPhaseApplied means the requested changes were patched onto the parent LanguageAgent.<br /> |
+| `Failed` | SelfConfigPhaseFailed means the controller encountered an error while processing the request.<br /> |
+| `Denied` | SelfConfigPhaseDenied means the request was rejected due to policy (not enabled, or action not allowed).<br /> |
+
+
+#### SelfConfigureSpec
+
+
+
+SelfConfigureSpec controls whether a LanguageAgent may submit LanguageAgentSelfConfig
+requests to modify its own spec at runtime.
+
+
+
+_Appears in:_
+- [LanguageAgentSpec](#languageagentspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `enabled` _boolean_ | Enabled gates all self-configuration. When false, any LanguageAgentSelfConfig<br />targeting this agent is immediately Denied. | false | Optional: \{\} <br /> |
+| `allowedActions` _[SelfConfigAction](#selfconfigaction) array_ | AllowedActions is the allowlist of self-config categories the agent may request.<br />If empty while Enabled=true, all actions are denied. |  | Enum: [tools models envVars instructions roleRules] <br />Optional: \{\} <br /> |
 
 
 #### ServiceReference
@@ -774,7 +1141,24 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `name` _string_ | Service name |  | Required: \{\} <br /> |
-| `namespace` _string_ | Service namespace (defaults to same namespace if omitted) |  |  |
+| `namespace` _string_ | Service namespace (defaults to same namespace if omitted) |  | Optional: \{\} <br /> |
+
+
+#### StdioServerSpec
+
+
+
+StdioServerSpec describes a stdio-based MCP server the operator wraps with a persistent
+stdio→Streamable-HTTP bridge.
+
+
+
+_Appears in:_
+- [LanguageToolSpec](#languagetoolspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `command` _string array_ | Command is the full argv of the stdio MCP server, e.g.<br />["npx","-y","@upstash/context7-mcp"] or ["uvx","mcp-server-git","--repository","/workspace"].<br />The operator passes it to the bridge as a single stdio command. Environment for the<br />child comes from spec.deployment.env / spec.deployment.envFrom. |  | MinItems: 1 <br />Required: \{\} <br /> |
 
 
 #### ToolProperty
@@ -791,8 +1175,8 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `type` _string_ | Type is the JSON schema type (string, integer, boolean, etc.) |  |  |
-| `description` _string_ | Description explains what this property represents |  |  |
-| `example` _string_ | Example provides an example value as a JSON string |  |  |
+| `description` _string_ | Description explains what this property represents |  | Optional: \{\} <br /> |
+| `example` _string_ | Example provides an example value as a JSON string |  | Optional: \{\} <br /> |
 
 
 #### ToolReference
@@ -809,7 +1193,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `name` _string_ | Name is the name of the LanguageTool |  | MaxLength: 63 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` <br />Required: \{\} <br /> |
-| `enabled` _boolean_ | Enabled indicates if this tool is available to the agent.<br />Defaults to true. Set to false to explicitly disable the tool without removing it. | true |  |
+| `enabled` _boolean_ | Enabled indicates if this tool is available to the agent.<br />Defaults to true. Set to false to explicitly disable the tool without removing it. | true | Optional: \{\} <br /> |
 
 
 #### ToolSchema
@@ -826,8 +1210,8 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `name` _string_ | Name is the tool identifier |  |  |
-| `description` _string_ | Description is a human-readable description of the tool |  |  |
-| `inputSchema` _[ToolSchemaDefinition](#toolschemadefinition)_ | InputSchema defines the parameters this tool accepts |  |  |
+| `description` _string_ | Description is a human-readable description of the tool |  | Optional: \{\} <br /> |
+| `inputSchema` _[ToolSchemaDefinition](#toolschemadefinition)_ | InputSchema defines the parameters this tool accepts |  | Optional: \{\} <br /> |
 
 
 #### ToolSchemaDefinition
@@ -843,9 +1227,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `type` _string_ | Type is the JSON schema type (object, array, string, etc.) |  |  |
-| `properties` _object (keys:string, values:[ToolProperty](#toolproperty))_ | Properties defines object properties (for type: object) |  |  |
-| `required` _string array_ | Required lists required property names (for type: object) |  |  |
+| `type` _string_ | Type is the JSON schema type (object, array, string, etc.) |  | Optional: \{\} <br /> |
+| `properties` _object (keys:string, values:[ToolProperty](#toolproperty))_ | Properties defines object properties (for type: object) |  | Optional: \{\} <br /> |
+| `required` _string array_ | Required lists required property names (for type: object) |  | Optional: \{\} <br /> |
 
 
 #### WorkspaceSpec
@@ -862,10 +1246,13 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `enabled` _boolean_ | Enabled controls whether to create a workspace volume.<br />Defaults to true. Set to false to explicitly disable without removing the workspace config. | true |  |
-| `size` _string_ | Size is the requested storage size (e.g., "10Gi", "1.5Ti", "500Mi")<br />Supports integer and decimal quantities with standard Kubernetes suffixes | 10Gi | MinLength: 1 <br />Pattern: `^([0-9]*\.?[0-9]+)(Ei\|Pi\|Ti\|Gi\|Mi\|Ki\|E\|P\|T\|G\|M\|K\|m)?$` <br /> |
-| `storageClassName` _string_ | StorageClassName specifies the StorageClass for the PVC<br />If not specified, uses the cluster default |  |  |
-| `accessMode` _string_ | AccessMode defines the volume access mode | ReadWriteOnce | Enum: [ReadWriteOnce ReadWriteMany] <br /> |
-| `mountPath` _string_ | MountPath is where the workspace is mounted in containers | /workspace |  |
+| `enabled` _boolean_ | Enabled controls whether to create a workspace volume.<br />Defaults to true. Set to false to explicitly disable without removing the workspace config. | true | Optional: \{\} <br /> |
+| `size` _string_ | Size is the requested storage size (e.g., "10Gi", "1.5Ti", "500Mi")<br />Supports integer and decimal quantities with standard Kubernetes suffixes | 10Gi | MinLength: 1 <br />Pattern: `^([0-9]*\.?[0-9]+)(Ei\|Pi\|Ti\|Gi\|Mi\|Ki\|E\|P\|T\|G\|M\|K\|m)?$` <br />Optional: \{\} <br /> |
+| `storageClassName` _string_ | StorageClassName specifies the StorageClass for the PVC<br />If not specified, uses the cluster default |  | Optional: \{\} <br /> |
+| `accessMode` _string_ | AccessMode defines the volume access mode | ReadWriteOnce | Enum: [ReadWriteOnce ReadWriteMany] <br />Optional: \{\} <br /> |
+| `mountPath` _string_ | MountPath is where the workspace is mounted in containers | /workspace | Optional: \{\} <br /> |
+| `retain` _boolean_ | Retain prevents the workspace PVC from being deleted when the agent is deleted.<br />When true, the PVC's ownerReference is removed during cleanup so Kubernetes GC<br />does not collect it. The orphaned PVC name is surfaced in status.workspacePVCName.<br />Defaults to false. | false | Optional: \{\} <br /> |
+| `initialFiles` _object (keys:string, values:string)_ | InitialFiles are seeded into the workspace PVC on first boot only.<br />Keys are filenames (must be valid ConfigMap keys: alphanumeric, '.', '-', '_').<br />Files are not overwritten if they already exist on the PVC. |  | Optional: \{\} <br /> |
+| `seedConfigMapRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ | SeedConfigMapRef references an external ConfigMap whose keys are filenames<br />and values are file contents. Merged with InitialFiles; InitialFiles wins on collision. |  | Optional: \{\} <br /> |
 
 


### PR DESCRIPTION
Closes #879

Documents the `spec.repository` field and `AGENT_REPO_DIR` env var that landed in #880 (CRD + webhook) and #881 (clone init container).

- **`docs/api/languageagent.md`** — new `### Repository` section with the `RepositorySpec` field table, clone-once behavior, and a private-repo (`secretRef`) example; `AGENT_REPO_DIR` added to the env-var table.
- **`docs/components/agents.md`** — new `## Repository` section covering the `repository` init container and credential handling; `AGENT_REPO_DIR` added to the env-var table.
- **`spec/agents.md`** — new `### Repository Cloning` runtime-contract subsection (init container ordering, clone-once `.git` check, working directory, credentials); `AGENT_REPO_DIR` added to the env-var table.
- **`src/docs/api-reference.md`** — regenerated via `make docs` to pick up the `RepositorySpec` struct.

Verified with `make docs-build` (strict) — exits clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)