### PR TITLE
fix: sort gateway config-hash keys to stop reconcile hot-loop

### DIFF
--- a/charts/language-operator-runtimes/Chart.lock
+++ b/charts/language-operator-runtimes/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 0.1.0
 - name: opencode
   repository: oci://ghcr.io/language-operator/charts
-  version: 0.1.2
-digest: sha256:d85f7c8945debfe38cb462961087beda267096010a6a0bf77924bcce4d509399
-generated: "2026-06-12T23:23:56.342950749-05:00"
+  version: 0.1.3
+digest: sha256:0715e7f111605b6b42e49cbdd8844d30346c4a9fcb07252c500b74b487d99c06
+generated: "2026-06-13T19:26:29.847381732-05:00"

--- a/charts/language-operator-runtimes/Chart.yaml
+++ b/charts/language-operator-runtimes/Chart.yaml
@@ -29,6 +29,6 @@ dependencies:
     repository: oci://ghcr.io/language-operator/charts
     condition: openclaw.enabled
   - name: opencode
-    version: "0.1.2"
+    version: "0.1.3"
     repository: oci://ghcr.io/language-operator/charts
     condition: opencode.enabled

--- a/src/controllers/languagecluster_controller.go
+++ b/src/controllers/languagecluster_controller.go
@@ -25,6 +25,7 @@ import (
 	"maps"
 	"net"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -1072,6 +1073,7 @@ func (r *LanguageClusterReconciler) reconcileGateway(ctx context.Context, cluste
 	for k := range cmData {
 		keys = append(keys, k)
 	}
+	sort.Strings(keys)
 	for _, k := range keys {
 		h.Write([]byte(k))
 		h.Write([]byte(cmData[k]))


### PR DESCRIPTION
## Problem

The shared LiteLLM gateway never ran a stable pod. The `languagecluster` controller was stuck in a reconcile hot-loop — the gateway Deployment's `metadata.generation` was observed at **>855,000** and climbing ~30/sec, with a fresh reconcile firing every few milliseconds.

## Root cause

`reconcileGateway` computed the gateway config-hash by iterating the ConfigMap data map in Go's **randomized map-iteration order**, without sorting the keys first. Every reconcile produced a different hash for identical model config. That hash is stamped onto the gateway pod template as the `langop.io/config-hash` annotation, so the pod template changed on every reconcile → new ReplicaSet/rollout → the owned-Deployment watch fired → re-reconcile → another random hash. Endless loop.

With `maxUnavailable=0`/`maxSurge=1`, pods were killed before reaching Ready, so the gateway never stabilized. Three ReplicaSets created seconds apart carried three different config-hashes for the same 3 models — confirming the non-determinism.

## Fix

`sort.Strings(keys)` before hashing, so the config-hash is deterministic for a given set of models.

## Verification

- `go build` / `go vet` pass.
- Full `./controllers` test suite passes (pre-commit hook).
- Audited the other config-hash sites — `languageagent_config.go` hashes fully-serialized YAML and `dex_templates.go` already sorts its paths; both deterministic. This was the only affected site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)