### PR TITLE
fix: stop auth reconcile hot-loop + add language-operator-team example

### DIFF
--- a/charts/language-operator-runtimes/Chart.lock
+++ b/charts/language-operator-runtimes/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: claude-code
   repository: oci://ghcr.io/language-operator/charts
-  version: 0.1.2
+  version: 0.1.3
 - name: openclaw
   repository: oci://ghcr.io/language-operator/charts
   version: 0.1.0
 - name: opencode
   repository: oci://ghcr.io/language-operator/charts
   version: 0.1.3
-digest: sha256:0715e7f111605b6b42e49cbdd8844d30346c4a9fcb07252c500b74b487d99c06
-generated: "2026-06-13T19:26:29.847381732-05:00"
+digest: sha256:cebbd19b0bfc05c6da1cc8001186d2ed1fe30621a9215b4062b20ec0b15c2648
+generated: "2026-06-22T18:51:36.753799835-05:00"

--- a/charts/language-operator-runtimes/Chart.yaml
+++ b/charts/language-operator-runtimes/Chart.yaml
@@ -21,7 +21,7 @@ maintainers:
 # them; toggle individual runtimes via the `<runtime>.enabled` values.
 dependencies:
   - name: claude-code
-    version: "0.1.2"
+    version: "0.1.3"
     repository: oci://ghcr.io/language-operator/charts
     condition: claude-code.enabled
   - name: openclaw

--- a/examples/development-team/languagetool.context7.yaml
+++ b/examples/development-team/languagetool.context7.yaml
@@ -16,6 +16,11 @@ spec:
       - -y
       - "@upstash/context7-mcp"
   deployment:
+    # The Node MCP server grows past the operator's 512Mi default and gets OOMKilled;
+    # give it 1Gi of headroom.
+    resources:
+      limits:
+        memory: 1Gi
     env:
       # The API key is optional: without it Context7 still works, just at a lower rate limit.
       # optional:true lets the pod start when the secret is absent (install without an API key).

--- a/examples/language-operator-team/README.md
+++ b/examples/language-operator-team/README.md
@@ -1,0 +1,140 @@
+# language-operator-team
+
+Deploys the full Language Operator engineering team into an existing LanguageCluster: the
+[development-team](../development-team/) (a supervisor that triages the core repo's issues into
+priority queues + three workers that implement them) **plus** one self-contained maintainer
+agent for each of the three sister adapter repositories.
+
+Each agent declares its repo via `spec.repository`, so the operator clones it into the agent's
+workspace on init and starts the runtime inside the checkout (exposed as `$AGENT_REPO_DIR`) — no
+manual `git clone` in the prompt. Every agent uses the `claude-code` runtime.
+
+```
+# core repo (language-operator/language-operator)
+supervisor (project-manager persona)
+  └─ reads open issues → assigns queue/0, queue/1, queue/2 labels
+
+worker-0 (engineer persona)  ← queue/0: urgent (bugs, failing CI, security)
+worker-1 (engineer persona)  ← queue/1: normal (features, improvements)
+worker-2 (engineer persona)  ← queue/2: backlog (chores, docs, cleanup)
+
+# sister adapter repos — one self-contained agent each (triages AND implements its own repo)
+adapter-claude-code (engineer persona)  → language-operator/claude-code-adapter
+adapter-openclaw    (engineer persona)  → language-operator/openclaw-adapter
+adapter-opencode    (engineer persona)  → language-operator/opencode-adapter
+```
+
+Unlike the queue-based core workers, each `adapter-*` agent owns a single repo end to end: it
+runs its own triage+implement loop (pick the highest-priority open, non-`in-progress` issue →
+implement → PR → merge → loop). A single agent per repo serializes naturally, so no queues or
+supervisor are needed for the adapters.
+
+All seven agents reference the [`context7`](../tools/context7/) `LanguageTool`, giving them
+up-to-date, version-specific library documentation over MCP so they stop coding against stale or
+hallucinated APIs.
+
+> The three `adapter-*` agents hardcode their `spec.repository.url` to the
+> `language-operator/<name>-adapter` repos. Edit those URLs in
+> `languageagent.adapter-*.yaml` if you work against forks.
+
+## Prerequisites
+
+- Language Operator [installed](https://langop.io/docs/getting-started/installation/)
+- `language-operator-runtimes` chart installed (provides the `claude-code` runtime)
+- `kubectl` configured for your cluster
+- `envsubst` (`brew install gettext` on macOS, pre-installed on most Linux distros)
+- A `LanguageCluster` already applied in the target namespace (see [clusters/basic](../clusters/basic/))
+- A Claude account (Pro, Max, Team, or Enterprise)
+- A GitHub personal access token with `repo` and `issues` scopes — used both to authenticate the clones (`spec.repository.secretRef`) and for the agents' `gh` operations. The same token must have access to the core repo **and** the three adapter repos.
+
+## Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `CLUSTER_NAME` | yes | — | Namespace of the target LanguageCluster |
+| `GITHUB_TOKEN` | yes | — | GitHub PAT (`repo`, `issues` scopes) — written to `github-credentials/token` secret; used for the clones and for `gh`. Needs access to the core repo and all three adapter repos. |
+| `PROJECT_REPOSITORY` | yes | — | Clone URL of the **core** repo the supervisor/workers work on (e.g. `https://github.com/language-operator/language-operator.git`). Cloned into each core agent's workspace via `spec.repository`. The adapter agents hardcode their own repo URLs. |
+| `PROJECT_NAME` | no | repo basename (minus `.git`) | Human-readable project name used in the core agents' prompts (e.g. `Language Operator`) |
+| `ANTHROPIC_API_KEY` | no | — | If set, written to `anthropic-credentials/api-key` and injected as `ANTHROPIC_API_KEY` on every agent (API-key billing). |
+| `CLAUDE_CODE_OAUTH_TOKEN` | no | — | Long-lived subscription token from `claude setup-token`. Written to `claude-code-oauth/token` and injected as `CLAUDE_CODE_OAUTH_TOKEN` (subscription billing, headless — no `/login` needed). |
+| `CONTEXT7_API_KEY` | no | — | [Context7 API key](https://context7.com/dashboard) for higher rate limits. Written to `context7-mcp-credentials/api-key`. The `context7` tool works without it at a lower rate limit. |
+
+If neither `ANTHROPIC_API_KEY` nor `CLAUDE_CODE_OAUTH_TOKEN` is set, agents authenticate interactively via `/login` in each terminal.
+
+## Install
+
+```bash
+CLUSTER_NAME=my-cluster \
+  GITHUB_TOKEN=ghp_... \
+  PROJECT_REPOSITORY=https://github.com/language-operator/language-operator.git \
+  PROJECT_NAME="Language Operator" \
+  bash examples/language-operator-team/install.sh
+```
+
+Dry-run (prints rendered YAML, skips secret creation):
+```bash
+CLUSTER_NAME=my-cluster \
+  GITHUB_TOKEN=ghp_... \
+  PROJECT_REPOSITORY=https://github.com/language-operator/language-operator.git \
+  bash examples/language-operator-team/install.sh --dry-run
+```
+
+## First-time setup
+
+If you provided `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`, no per-agent setup is needed — agents authenticate non-interactively. Otherwise, open each agent's terminal and run `/login` inside Claude Code. Credentials are saved to `/workspace/.claude/.credentials.json` and persist across pod restarts.
+
+To mint a long-lived OAuth token (subscription billing, no browser needed): run `claude setup-token` on your laptop and pass the result as `CLAUDE_CODE_OAUTH_TOKEN`.
+
+```bash
+kubectl port-forward -n my-cluster svc/supervisor 8080:8080
+# open http://localhost:8080, run /login
+# ... repeat for worker-0/1/2 and adapter-claude-code/openclaw/opencode
+```
+
+## What's created
+
+- `Secret/github-credentials` — GitHub PAT
+- `Secret/anthropic-credentials` — Anthropic API key (only if `ANTHROPIC_API_KEY` was set)
+- `Secret/claude-code-oauth` — Claude Code OAuth token (only if `CLAUDE_CODE_OAUTH_TOKEN` was set)
+- `Secret/context7-mcp-credentials` — Context7 API key (only if `CONTEXT7_API_KEY` was set)
+- `LanguagePersona/project-manager` — supervisor behavioral config
+- `LanguagePersona/engineer` — worker/adapter behavioral config
+- `LanguageTool/context7` — Context7 MCP tool referenced by every agent; the operator generates its `Deployment` and `Service`
+- `LanguageAgent/supervisor` — triages the core repo's issues; 5Gi workspace
+- `LanguageAgent/worker-0` — queue/0 (urgent); 10Gi workspace; uses `context7`
+- `LanguageAgent/worker-1` — queue/1 (normal); 10Gi workspace; uses `context7`
+- `LanguageAgent/worker-2` — queue/2 (backlog); 10Gi workspace; uses `context7`
+- `LanguageAgent/adapter-claude-code` — owns `claude-code-adapter`; 10Gi workspace; uses `context7`
+- `LanguageAgent/adapter-openclaw` — owns `openclaw-adapter`; 10Gi workspace; uses `context7`
+- `LanguageAgent/adapter-opencode` — owns `opencode-adapter`; 10Gi workspace; uses `context7`
+
+Each `LanguageAgent` also produces a `Deployment`, `Service`, `NetworkPolicy`, `PersistentVolumeClaim`, and `ConfigMap`. Because each agent sets `spec.repository`, the operator injects a `repository` init container that clones the repo into the workspace (authenticated with `github-credentials`) and points the runtime's working directory at the checkout via `$AGENT_REPO_DIR`.
+
+## Access
+
+### With OIDC auth (cluster has a domain)
+
+```
+https://supervisor.<your-domain>
+https://worker-0.<your-domain>
+https://adapter-claude-code.<your-domain>
+... (one host per agent)
+```
+
+Sign in through the OIDC provider configured on the cluster.
+
+### Local access (port-forward)
+
+```bash
+kubectl port-forward -n my-cluster svc/adapter-openclaw 8080:8080
+# open http://localhost:8080
+```
+
+Type a prompt in the terminal to trigger a pass. Use the same pattern for any agent.
+
+## Teardown
+
+```bash
+kubectl delete -k examples/language-operator-team/ -n my-cluster
+kubectl delete secret github-credentials anthropic-credentials claude-code-oauth context7-mcp-credentials -n my-cluster --ignore-not-found
+```

--- a/examples/language-operator-team/install.sh
+++ b/examples/language-operator-team/install.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Usage: CLUSTER_NAME=my-cluster GITHUB_TOKEN=ghp_... PROJECT_REPOSITORY=https://github.com/owner/repo.git bash install.sh [--dry-run]
+set -euo pipefail
+
+: "${CLUSTER_NAME:?CLUSTER_NAME is required — set it to the name of your LanguageCluster}"
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is required (gh PAT with repo, issues scopes)}"
+: "${PROJECT_REPOSITORY:?PROJECT_REPOSITORY is required (clone URL, e.g. https://github.com/language-operator/language-operator.git)}"
+export CLUSTER_NAME
+export PROJECT_REPOSITORY
+# Derive a human-readable default project name from the URL basename (strip trailing slash and .git).
+_repo_base="${PROJECT_REPOSITORY%/}"; _repo_base="${_repo_base##*/}"; _repo_base="${_repo_base%.git}"
+export PROJECT_NAME="${PROJECT_NAME:-$_repo_base}"
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Restrict substitution to our install vars so literal shell references in agent
+# instructions (e.g. $AGENT_REPO_DIR, injected by the operator at runtime) survive.
+for f in "$DIR"/*.yaml; do
+    envsubst '${CLUSTER_NAME} ${PROJECT_NAME} ${PROJECT_REPOSITORY}' < "$f" > "$TMPDIR/$(basename "$f")"
+done
+
+if $DRY_RUN; then
+    kubectl kustomize "$TMPDIR"
+    exit 0
+fi
+
+kubectl create secret generic github-credentials \
+    --from-literal=token="$GITHUB_TOKEN" \
+    --namespace "$CLUSTER_NAME" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+    kubectl create secret generic anthropic-credentials \
+        --from-literal=api-key="$ANTHROPIC_API_KEY" \
+        --namespace "$CLUSTER_NAME" \
+        --dry-run=client -o yaml | kubectl apply -f -
+fi
+
+if [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+    kubectl create secret generic claude-code-oauth \
+        --from-literal=token="$CLAUDE_CODE_OAUTH_TOKEN" \
+        --namespace "$CLUSTER_NAME" \
+        --dry-run=client -o yaml | kubectl apply -f -
+fi
+
+# Context7 API key is optional — the tool works without it at a lower rate limit
+# and references the secret with optional:true, so the pod starts either way.
+if [[ -n "${CONTEXT7_API_KEY:-}" ]]; then
+    kubectl create secret generic context7-mcp-credentials \
+        --from-literal=api-key="$CONTEXT7_API_KEY" \
+        --namespace "$CLUSTER_NAME" \
+        --dry-run=client -o yaml | kubectl apply -f -
+fi
+
+kubectl kustomize "$TMPDIR" | kubectl apply -f -

--- a/examples/language-operator-team/kustomization.yaml
+++ b/examples/language-operator-team/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - languagepersona.project-manager.yaml
+  - languagepersona.engineer.yaml
+  - languagetool.context7.yaml
+  - languageagent.supervisor.yaml
+  - languageagent.worker-0.yaml
+  - languageagent.worker-1.yaml
+  - languageagent.worker-2.yaml
+  - languageagent.adapter-claude-code.yaml
+  - languageagent.adapter-openclaw.yaml
+  - languageagent.adapter-opencode.yaml

--- a/examples/language-operator-team/languageagent.adapter-claude-code.yaml
+++ b/examples/language-operator-team/languageagent.adapter-claude-code.yaml
@@ -1,0 +1,102 @@
+apiVersion: langop.io/v1alpha1
+kind: LanguageAgent
+metadata:
+  name: adapter-claude-code
+  namespace: ${CLUSTER_NAME}
+spec:
+  runtime: claude-code
+  persona: engineer
+  tools:
+    - name: context7
+  instructions: |
+    You are the maintainer agent for the claude-code-adapter repository — the
+    sister repo that builds the combined terminal image and the `claude-code`
+    runtime Helm chart for Language Operator. You own this single repo end to
+    end: you both triage and implement its open issues.
+
+    You start in a checkout of claude-code-adapter (the operator clones it into
+    your workspace and opens your shell there), so `gh` and git operate on the
+    repo without any setup.
+
+    On each invocation:
+
+    1. List open issues that are not labelled "in-progress". Pick the single
+       highest-priority one (urgent bugs and failing CI first, then features,
+       then chores/docs). If there are none, report idle and stop.
+
+    2. Read the issue thoroughly (title, body, comments).
+
+    3. Investigate whether the issue is valid. If invalid (misuse of a feature,
+       duplicate, out of date), comment with the rationale and close it, then
+       loop back to step 1. Otherwise continue.
+
+    4. Label the issue "in-progress". Create a branch off the main branch for
+       your changes.
+
+    5. Implement the change. Follow project conventions documented in the repo
+       (e.g. CLAUDE.md, README, CONTRIBUTING) when present. This repo ships a
+       container image and a Helm chart — when you touch either, lint/build it
+       the way the repo documents.
+
+    6. Run the project's tests. Add new tests as appropriate.
+
+    7. Commit with a conventional one-line message (feat:, fix:, chore:, etc.)
+       and push the branch.
+
+    8. Open a PR with a title matching the commit and body "Closes #<N>".
+
+    9. Poll CI until all checks complete. Push fixups until everything is green.
+
+    10. Squash-merge the PR and delete the branch.
+
+    11. Comment on the issue with resolution details, remove the in-progress
+        label, and close the issue.
+
+    12. Loop: go back to step 1 until there is no actionable work left.
+
+    Use `gh` for all GitHub operations. When implementing against a library or
+    framework, consult the context7 MCP tool for up-to-date, version-specific
+    documentation rather than relying on memory.
+  repository:
+    url: https://github.com/language-operator/claude-code-adapter.git
+    secretRef:
+      name: github-credentials
+  networkPolicies:
+    egress:
+      - to:
+          - cidr: "0.0.0.0/0"
+        ports:
+          - port: 443
+            protocol: TCP
+          - port: 80
+            protocol: TCP
+  workspace:
+    size: 10Gi
+  deployment:
+    # Adapter agents compile and test the repo and build container/chart
+    # artifacts — peaks in the multi-GiB range and wants several cores.
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: 4000m
+        memory: 6Gi
+    env:
+      - name: GITHUB_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: github-credentials
+            key: token
+      - name: ANTHROPIC_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: anthropic-credentials
+            key: api-key
+            optional: true
+      - name: CLAUDE_CODE_OAUTH_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: claude-code-oauth
+            key: token
+            optional: true

--- a/examples/language-operator-team/languageagent.adapter-openclaw.yaml
+++ b/examples/language-operator-team/languageagent.adapter-openclaw.yaml
@@ -1,0 +1,102 @@
+apiVersion: langop.io/v1alpha1
+kind: LanguageAgent
+metadata:
+  name: adapter-openclaw
+  namespace: ${CLUSTER_NAME}
+spec:
+  runtime: claude-code
+  persona: engineer
+  tools:
+    - name: context7
+  instructions: |
+    You are the maintainer agent for the openclaw-adapter repository — the
+    sister repo that builds the adapter init image and the `openclaw` runtime
+    Helm chart for Language Operator. You own this single repo end to end: you
+    both triage and implement its open issues.
+
+    You start in a checkout of openclaw-adapter (the operator clones it into
+    your workspace and opens your shell there), so `gh` and git operate on the
+    repo without any setup.
+
+    On each invocation:
+
+    1. List open issues that are not labelled "in-progress". Pick the single
+       highest-priority one (urgent bugs and failing CI first, then features,
+       then chores/docs). If there are none, report idle and stop.
+
+    2. Read the issue thoroughly (title, body, comments).
+
+    3. Investigate whether the issue is valid. If invalid (misuse of a feature,
+       duplicate, out of date), comment with the rationale and close it, then
+       loop back to step 1. Otherwise continue.
+
+    4. Label the issue "in-progress". Create a branch off the main branch for
+       your changes.
+
+    5. Implement the change. Follow project conventions documented in the repo
+       (e.g. CLAUDE.md, README, CONTRIBUTING) when present. This repo ships a
+       container image and a Helm chart — when you touch either, lint/build it
+       the way the repo documents.
+
+    6. Run the project's tests. Add new tests as appropriate.
+
+    7. Commit with a conventional one-line message (feat:, fix:, chore:, etc.)
+       and push the branch.
+
+    8. Open a PR with a title matching the commit and body "Closes #<N>".
+
+    9. Poll CI until all checks complete. Push fixups until everything is green.
+
+    10. Squash-merge the PR and delete the branch.
+
+    11. Comment on the issue with resolution details, remove the in-progress
+        label, and close the issue.
+
+    12. Loop: go back to step 1 until there is no actionable work left.
+
+    Use `gh` for all GitHub operations. When implementing against a library or
+    framework, consult the context7 MCP tool for up-to-date, version-specific
+    documentation rather than relying on memory.
+  repository:
+    url: https://github.com/language-operator/openclaw-adapter.git
+    secretRef:
+      name: github-credentials
+  networkPolicies:
+    egress:
+      - to:
+          - cidr: "0.0.0.0/0"
+        ports:
+          - port: 443
+            protocol: TCP
+          - port: 80
+            protocol: TCP
+  workspace:
+    size: 10Gi
+  deployment:
+    # Adapter agents compile and test the repo and build container/chart
+    # artifacts — peaks in the multi-GiB range and wants several cores.
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: 4000m
+        memory: 6Gi
+    env:
+      - name: GITHUB_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: github-credentials
+            key: token
+      - name: ANTHROPIC_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: anthropic-credentials
+            key: api-key
+            optional: true
+      - name: CLAUDE_CODE_OAUTH_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: claude-code-oauth
+            key: token
+            optional: true

--- a/examples/language-operator-team/languageagent.adapter-opencode.yaml
+++ b/examples/language-operator-team/languageagent.adapter-opencode.yaml
@@ -1,0 +1,102 @@
+apiVersion: langop.io/v1alpha1
+kind: LanguageAgent
+metadata:
+  name: adapter-opencode
+  namespace: ${CLUSTER_NAME}
+spec:
+  runtime: claude-code
+  persona: engineer
+  tools:
+    - name: context7
+  instructions: |
+    You are the maintainer agent for the opencode-adapter repository — the
+    sister repo that builds the adapter init image and the `opencode` runtime
+    Helm chart for Language Operator. You own this single repo end to end: you
+    both triage and implement its open issues.
+
+    You start in a checkout of opencode-adapter (the operator clones it into
+    your workspace and opens your shell there), so `gh` and git operate on the
+    repo without any setup.
+
+    On each invocation:
+
+    1. List open issues that are not labelled "in-progress". Pick the single
+       highest-priority one (urgent bugs and failing CI first, then features,
+       then chores/docs). If there are none, report idle and stop.
+
+    2. Read the issue thoroughly (title, body, comments).
+
+    3. Investigate whether the issue is valid. If invalid (misuse of a feature,
+       duplicate, out of date), comment with the rationale and close it, then
+       loop back to step 1. Otherwise continue.
+
+    4. Label the issue "in-progress". Create a branch off the main branch for
+       your changes.
+
+    5. Implement the change. Follow project conventions documented in the repo
+       (e.g. CLAUDE.md, README, CONTRIBUTING) when present. This repo ships a
+       container image and a Helm chart — when you touch either, lint/build it
+       the way the repo documents.
+
+    6. Run the project's tests. Add new tests as appropriate.
+
+    7. Commit with a conventional one-line message (feat:, fix:, chore:, etc.)
+       and push the branch.
+
+    8. Open a PR with a title matching the commit and body "Closes #<N>".
+
+    9. Poll CI until all checks complete. Push fixups until everything is green.
+
+    10. Squash-merge the PR and delete the branch.
+
+    11. Comment on the issue with resolution details, remove the in-progress
+        label, and close the issue.
+
+    12. Loop: go back to step 1 until there is no actionable work left.
+
+    Use `gh` for all GitHub operations. When implementing against a library or
+    framework, consult the context7 MCP tool for up-to-date, version-specific
+    documentation rather than relying on memory.
+  repository:
+    url: https://github.com/language-operator/opencode-adapter.git
+    secretRef:
+      name: github-credentials
+  networkPolicies:
+    egress:
+      - to:
+          - cidr: "0.0.0.0/0"
+        ports:
+          - port: 443
+            protocol: TCP
+          - port: 80
+            protocol: TCP
+  workspace:
+    size: 10Gi
+  deployment:
+    # Adapter agents compile and test the repo and build container/chart
+    # artifacts — peaks in the multi-GiB range and wants several cores.
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: 4000m
+        memory: 6Gi
+    env:
+      - name: GITHUB_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: github-credentials
+            key: token
+      - name: ANTHROPIC_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: anthropic-credentials
+            key: api-key
+            optional: true
+      - name: CLAUDE_CODE_OAUTH_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: claude-code-oauth
+            key: token
+            optional: true

--- a/examples/language-operator-team/languageagent.supervisor.yaml
+++ b/examples/language-operator-team/languageagent.supervisor.yaml
@@ -1,0 +1,72 @@
+apiVersion: langop.io/v1alpha1
+kind: LanguageAgent
+metadata:
+  name: supervisor
+  namespace: ${CLUSTER_NAME}
+spec:
+  runtime: claude-code
+  persona: project-manager
+  instructions: |
+    You are the supervisor for the ${PROJECT_NAME} engineering team. Your job
+    is to triage open GitHub issues into priority queues (queue/0, queue/1,
+    queue/2) so worker agents can pick them up.
+
+    You start in a checkout of the project repository (the operator clones it
+    into your workspace and opens your shell there), so `gh` and git operate on
+    the project without any setup.
+
+    On each invocation:
+
+    1. Clear stale queue labels from all open issues (remove queue/0, queue/1,
+       queue/2 from any issue currently carrying them).
+
+    2. List open issues that have no queue label and are not labelled
+       "in-progress". If none, report idle and stop.
+
+    3. Analyze for conflict groups — issues touching the same files, modules,
+       or areas of the codebase must serialize. Independent areas can run in
+       parallel.
+
+    4. Label only the single highest-priority issue from each conflict group:
+         group 1 top → queue/0
+         group 2 top → queue/1
+         group 3 top → queue/2
+       Use fewer queues if there are fewer independent groups.
+
+    5. Print a summary: which issues went to which queues and why.
+
+    Use `gh` for all GitHub operations.
+  repository:
+    url: ${PROJECT_REPOSITORY}
+    secretRef:
+      name: github-credentials
+  networkPolicies:
+    egress:
+      - to:
+          - cidr: "0.0.0.0/0"
+        ports:
+          - port: 443
+            protocol: TCP
+          - port: 80
+            protocol: TCP
+  workspace:
+    size: 5Gi
+  deployment:
+    env:
+      - name: GITHUB_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: github-credentials
+            key: token
+      - name: ANTHROPIC_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: anthropic-credentials
+            key: api-key
+            optional: true
+      - name: CLAUDE_CODE_OAUTH_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: claude-code-oauth
+            key: token
+            optional: true

--- a/examples/language-operator-team/languageagent.worker-0.yaml
+++ b/examples/language-operator-team/languageagent.worker-0.yaml
@@ -1,0 +1,102 @@
+apiVersion: langop.io/v1alpha1
+kind: LanguageAgent
+metadata:
+  name: worker-0
+  namespace: ${CLUSTER_NAME}
+spec:
+  runtime: claude-code
+  persona: engineer
+  tools:
+    - name: context7
+  instructions: |
+    You are worker-0 for the ${PROJECT_NAME} engineering team, responsible for
+    queue/0 (urgent work). Your job is to continuously pick up issues from
+    queue/0, implement them, and open pull requests.
+
+    You start in a checkout of the project repository (the operator clones it
+    into your workspace and opens your shell there), so `gh` and git operate on
+    the project without any setup.
+
+    On each invocation:
+
+    1. Fetch the next open issue in queue/0. If empty, report idle and stop.
+
+    2. Read the issue thoroughly (title, body, comments).
+
+    3. Investigate whether the issue is valid. If invalid (misuse of a feature,
+       duplicate, out of date), comment with the rationale and close it.
+       Otherwise continue.
+
+    4. Label the issue "in-progress" and remove the queue/0 label. Create a
+       git worktree off the main branch for your changes so other workers can
+       run in parallel.
+
+    5. Implement the change. Follow project conventions documented in the repo
+       (e.g. CLAUDE.md, README, CONTRIBUTING) when present.
+
+    6. Run the project's tests. Add new tests as appropriate.
+
+    7. Commit with a conventional one-line message (feat:, fix:, chore:, etc.)
+       and push the branch.
+
+    8. Open a PR with a title matching the commit and body "Closes #<N>".
+
+    9. Poll CI until all checks complete. Push fixups until everything is
+       green.
+
+    10. Squash-merge the PR and delete the branch.
+
+    11. Clean up the worktree.
+
+    12. Comment on the issue with resolution details, remove the in-progress
+        label, and close the issue.
+
+    13. Loop: go back to step 1 until queue/0 is empty.
+
+    Use `gh` for all GitHub operations. When implementing against a library or
+    framework, consult the context7 MCP tool for up-to-date, version-specific
+    documentation rather than relying on memory.
+  repository:
+    url: ${PROJECT_REPOSITORY}
+    secretRef:
+      name: github-credentials
+  networkPolicies:
+    egress:
+      - to:
+          - cidr: "0.0.0.0/0"
+        ports:
+          - port: 443
+            protocol: TCP
+          - port: 80
+            protocol: TCP
+  workspace:
+    size: 10Gi
+  deployment:
+    # Workers compile and test arbitrary repos — go build / go test peak
+    # in the multi-GiB range and want several cores. Defaults (2Gi/1cpu)
+    # OOM-killed worker-0 during a build.
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: 4000m
+        memory: 6Gi
+    env:
+      - name: GITHUB_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: github-credentials
+            key: token
+      - name: ANTHROPIC_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: anthropic-credentials
+            key: api-key
+            optional: true
+      - name: CLAUDE_CODE_OAUTH_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: claude-code-oauth
+            key: token
+            optional: true

--- a/examples/language-operator-team/languageagent.worker-1.yaml
+++ b/examples/language-operator-team/languageagent.worker-1.yaml
@@ -1,0 +1,102 @@
+apiVersion: langop.io/v1alpha1
+kind: LanguageAgent
+metadata:
+  name: worker-1
+  namespace: ${CLUSTER_NAME}
+spec:
+  runtime: claude-code
+  persona: engineer
+  tools:
+    - name: context7
+  instructions: |
+    You are worker-1 for the ${PROJECT_NAME} engineering team, responsible for
+    queue/1 (normal work). Your job is to continuously pick up issues from
+    queue/1, implement them, and open pull requests.
+
+    You start in a checkout of the project repository (the operator clones it
+    into your workspace and opens your shell there), so `gh` and git operate on
+    the project without any setup.
+
+    On each invocation:
+
+    1. Fetch the next open issue in queue/1. If empty, report idle and stop.
+
+    2. Read the issue thoroughly (title, body, comments).
+
+    3. Investigate whether the issue is valid. If invalid (misuse of a feature,
+       duplicate, out of date), comment with the rationale and close it.
+       Otherwise continue.
+
+    4. Label the issue "in-progress" and remove the queue/1 label. Create a
+       git worktree off the main branch for your changes so other workers can
+       run in parallel.
+
+    5. Implement the change. Follow project conventions documented in the repo
+       (e.g. CLAUDE.md, README, CONTRIBUTING) when present.
+
+    6. Run the project's tests. Add new tests as appropriate.
+
+    7. Commit with a conventional one-line message (feat:, fix:, chore:, etc.)
+       and push the branch.
+
+    8. Open a PR with a title matching the commit and body "Closes #<N>".
+
+    9. Poll CI until all checks complete. Push fixups until everything is
+       green.
+
+    10. Squash-merge the PR and delete the branch.
+
+    11. Clean up the worktree.
+
+    12. Comment on the issue with resolution details, remove the in-progress
+        label, and close the issue.
+
+    13. Loop: go back to step 1 until queue/1 is empty.
+
+    Use `gh` for all GitHub operations. When implementing against a library or
+    framework, consult the context7 MCP tool for up-to-date, version-specific
+    documentation rather than relying on memory.
+  repository:
+    url: ${PROJECT_REPOSITORY}
+    secretRef:
+      name: github-credentials
+  networkPolicies:
+    egress:
+      - to:
+          - cidr: "0.0.0.0/0"
+        ports:
+          - port: 443
+            protocol: TCP
+          - port: 80
+            protocol: TCP
+  workspace:
+    size: 10Gi
+  deployment:
+    # Workers compile and test arbitrary repos — go build / go test peak
+    # in the multi-GiB range and want several cores. Defaults (2Gi/1cpu)
+    # OOM-killed worker-0 during a build.
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: 4000m
+        memory: 6Gi
+    env:
+      - name: GITHUB_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: github-credentials
+            key: token
+      - name: ANTHROPIC_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: anthropic-credentials
+            key: api-key
+            optional: true
+      - name: CLAUDE_CODE_OAUTH_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: claude-code-oauth
+            key: token
+            optional: true

--- a/examples/language-operator-team/languageagent.worker-2.yaml
+++ b/examples/language-operator-team/languageagent.worker-2.yaml
@@ -1,0 +1,102 @@
+apiVersion: langop.io/v1alpha1
+kind: LanguageAgent
+metadata:
+  name: worker-2
+  namespace: ${CLUSTER_NAME}
+spec:
+  runtime: claude-code
+  persona: engineer
+  tools:
+    - name: context7
+  instructions: |
+    You are worker-2 for the ${PROJECT_NAME} engineering team, responsible for
+    queue/2 (backlog). Your job is to continuously pick up issues from queue/2,
+    implement them, and open pull requests.
+
+    You start in a checkout of the project repository (the operator clones it
+    into your workspace and opens your shell there), so `gh` and git operate on
+    the project without any setup.
+
+    On each invocation:
+
+    1. Fetch the next open issue in queue/2. If empty, report idle and stop.
+
+    2. Read the issue thoroughly (title, body, comments).
+
+    3. Investigate whether the issue is valid. If invalid (misuse of a feature,
+       duplicate, out of date), comment with the rationale and close it.
+       Otherwise continue.
+
+    4. Label the issue "in-progress" and remove the queue/2 label. Create a
+       git worktree off the main branch for your changes so other workers can
+       run in parallel.
+
+    5. Implement the change. Follow project conventions documented in the repo
+       (e.g. CLAUDE.md, README, CONTRIBUTING) when present.
+
+    6. Run the project's tests. Add new tests as appropriate.
+
+    7. Commit with a conventional one-line message (feat:, fix:, chore:, etc.)
+       and push the branch.
+
+    8. Open a PR with a title matching the commit and body "Closes #<N>".
+
+    9. Poll CI until all checks complete. Push fixups until everything is
+       green.
+
+    10. Squash-merge the PR and delete the branch.
+
+    11. Clean up the worktree.
+
+    12. Comment on the issue with resolution details, remove the in-progress
+        label, and close the issue.
+
+    13. Loop: go back to step 1 until queue/2 is empty.
+
+    Use `gh` for all GitHub operations. When implementing against a library or
+    framework, consult the context7 MCP tool for up-to-date, version-specific
+    documentation rather than relying on memory.
+  repository:
+    url: ${PROJECT_REPOSITORY}
+    secretRef:
+      name: github-credentials
+  networkPolicies:
+    egress:
+      - to:
+          - cidr: "0.0.0.0/0"
+        ports:
+          - port: 443
+            protocol: TCP
+          - port: 80
+            protocol: TCP
+  workspace:
+    size: 10Gi
+  deployment:
+    # Workers compile and test arbitrary repos — go build / go test peak
+    # in the multi-GiB range and want several cores. Defaults (2Gi/1cpu)
+    # OOM-killed worker-0 during a build.
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: 4000m
+        memory: 6Gi
+    env:
+      - name: GITHUB_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: github-credentials
+            key: token
+      - name: ANTHROPIC_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: anthropic-credentials
+            key: api-key
+            optional: true
+      - name: CLAUDE_CODE_OAUTH_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: claude-code-oauth
+            key: token
+            optional: true

--- a/examples/language-operator-team/languagepersona.engineer.yaml
+++ b/examples/language-operator-team/languagepersona.engineer.yaml
@@ -1,0 +1,9 @@
+apiVersion: langop.io/v1alpha1
+kind: LanguagePersona
+metadata:
+  name: engineer
+  namespace: ${CLUSTER_NAME}
+spec:
+  tone: precise and technical
+  personality: methodical; writes clean idiomatic code; follows project conventions; verifies correctness with tests before closing a task
+  expertise: software engineering; reading and modifying unfamiliar codebases; Git workflow; GitHub CLI; CI/CD systems

--- a/examples/language-operator-team/languagepersona.project-manager.yaml
+++ b/examples/language-operator-team/languagepersona.project-manager.yaml
@@ -1,0 +1,9 @@
+apiVersion: langop.io/v1alpha1
+kind: LanguagePersona
+metadata:
+  name: project-manager
+  namespace: ${CLUSTER_NAME}
+spec:
+  tone: direct and decisive
+  personality: strategic and organized; breaks complex work into clear actionable tasks; communicates status concisely
+  expertise: software project management; GitHub issue triage and prioritization; coordinating distributed engineering teams

--- a/examples/language-operator-team/languagetool.context7.yaml
+++ b/examples/language-operator-team/languagetool.context7.yaml
@@ -1,0 +1,42 @@
+apiVersion: langop.io/v1alpha1
+kind: LanguageTool
+metadata:
+  name: context7
+  namespace: ${CLUSTER_NAME}
+spec:
+  # Context7 ships as a stdio MCP server. transport=stdio tells the operator to run it under a
+  # pinned, persistent stdio→Streamable-HTTP bridge (one long-lived child) and serve /mcp on
+  # spec.port. No supergateway flags, npm-cache volume, or HOME env are needed here — the
+  # operator injects the bridge, a writable cache + /tmp, and the readiness probe.
+  transport: stdio
+  port: 8080
+  stdio:
+    command:
+      - npx
+      - -y
+      - "@upstash/context7-mcp"
+  deployment:
+    # The Node MCP server grows past the operator's 512Mi default and gets OOMKilled;
+    # give it 1Gi of headroom.
+    resources:
+      limits:
+        memory: 1Gi
+    env:
+      # The API key is optional: without it Context7 still works, just at a lower rate limit.
+      # optional:true lets the pod start when the secret is absent (install without an API key).
+      - name: CONTEXT7_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: context7-mcp-credentials
+            key: api-key
+            optional: true
+  # The operator's default tool policy denies external egress. Context7 needs public HTTPS
+  # twice over: npx fetches the server package from the npm registry at boot, and the server
+  # calls Context7's API at runtime. Without this the pod can't start.
+  networkPolicies:
+    egress:
+      - to:
+          - cidr: "0.0.0.0/0"
+        ports:
+          - port: 443
+            protocol: TCP

--- a/examples/tools/context7/languagetool.context7.yaml
+++ b/examples/tools/context7/languagetool.context7.yaml
@@ -16,6 +16,11 @@ spec:
       - -y
       - "@upstash/context7-mcp"
   deployment:
+    # The Node MCP server grows past the operator's 512Mi default and gets OOMKilled;
+    # give it 1Gi of headroom.
+    resources:
+      limits:
+        memory: 1Gi
     env:
       # The API key is optional: without it Context7 still works, just at a lower rate limit.
       # optional:true lets the pod start when the secret is absent (install without an API key).

--- a/examples/tools/github/languagetool.github.yaml
+++ b/examples/tools/github/languagetool.github.yaml
@@ -15,6 +15,11 @@ spec:
       - -y
       - "@modelcontextprotocol/server-github"
   deployment:
+    # The Node MCP server grows past the operator's 512Mi default and gets OOMKilled;
+    # give it 1Gi of headroom.
+    resources:
+      limits:
+        memory: 1Gi
     env:
       - name: GITHUB_PERSONAL_ACCESS_TOKEN
         valueFrom:

--- a/examples/tools/postgres/languagetool.postgres.yaml
+++ b/examples/tools/postgres/languagetool.postgres.yaml
@@ -18,6 +18,11 @@ spec:
       - "@modelcontextprotocol/server-postgres"
       - "$DATABASE_URL"
   deployment:
+    # The Node MCP server grows past the operator's 512Mi default and gets OOMKilled;
+    # give it 1Gi of headroom.
+    resources:
+      limits:
+        memory: 1Gi
     env:
       # install.sh builds this DSN to point at the bundled in-cluster Postgres StatefulSet
       # (statefulset.postgres-db.yaml) and writes it to the secret's "url" key.

--- a/src/controllers/languagecluster_dex.go
+++ b/src/controllers/languagecluster_dex.go
@@ -23,6 +23,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"sort"
 
 	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
@@ -243,6 +244,13 @@ func (r *LanguageClusterReconciler) buildDexConfigYAML(cluster *langopv1alpha1.L
 			Name:         agent.Name,
 		})
 	}
+	// Sort by ID so the rendered YAML (and thus the config hash that drives the
+	// Dex pod-template rollout annotation) is deterministic. The agent list comes
+	// from a cached List whose iteration order is not stable; without this the
+	// hash flips every reconcile and Dex rolls out forever.
+	sort.Slice(staticClients, func(i, j int) bool {
+		return staticClients[i].ID < staticClients[j].ID
+	})
 
 	cfg := dexConfig{
 		Issuer:  issuer,

--- a/src/controllers/languagecluster_dex_test.go
+++ b/src/controllers/languagecluster_dex_test.go
@@ -178,6 +178,29 @@ func TestBuildDexConfigYAML_PerAgentClientName(t *testing.T) {
 	assert.Contains(t, yaml, "name: worker")
 }
 
+func TestBuildDexConfigYAML_DeterministicAgentOrder(t *testing.T) {
+	r := newDexReconciler(t)
+	cluster := authCluster("test")
+	// The agent list comes from a cached List whose iteration order is not
+	// stable. Differently-ordered inputs must render byte-identical YAML, else
+	// the config hash flips every reconcile and Dex rolls out forever.
+	forward := []langopv1alpha1.LanguageAgent{
+		*gen.LanguageAgent("alpha", "test"),
+		*gen.LanguageAgent("bravo", "test"),
+		*gen.LanguageAgent("charlie", "test"),
+	}
+	reversed := []langopv1alpha1.LanguageAgent{
+		*gen.LanguageAgent("charlie", "test"),
+		*gen.LanguageAgent("bravo", "test"),
+		*gen.LanguageAgent("alpha", "test"),
+	}
+	yamlForward, err := r.buildDexConfigYAML(cluster, "secret", forward)
+	require.NoError(t, err)
+	yamlReversed, err := r.buildDexConfigYAML(cluster, "secret", reversed)
+	require.NoError(t, err)
+	assert.Equal(t, yamlForward, yamlReversed)
+}
+
 func TestBuildDexConfigYAML_EnablePasswordDB(t *testing.T) {
 	r := newDexReconciler(t)
 	cluster := authCluster("test")


### PR DESCRIPTION
## Summary

Four related changes, surfaced while standing up a fuller team example:

- **fix: sort dex static clients to stop auth reconcile hot-loop** — The per-agent Dex static clients were built by ranging over a cached `List` whose iteration order is not stable, so the rendered Dex config YAML (and the config hash stamped on the Dex pod template) flipped on every reconcile, rolling the `auth` Deployment out endlessly. Sort the clients by ID before rendering, mirroring the gateway config-hash fix (#884). Adds a regression test asserting forward/reversed agent order render byte-identical YAML.
- **fix: set 1Gi memory limit on MCP tool examples** — The Node-based MCP servers (context7, postgres, github) grow past the operator's 512Mi default and get OOMKilled in a restart loop (observed 500+ restarts). Give them 1Gi of headroom.
- **feat: add `examples/language-operator-team`** — Clones the development-team (supervisor + worker-0/1/2 over the core repo) and adds one self-contained maintainer agent per sister adapter repo (claude-code-adapter, openclaw-adapter, opencode-adapter). Each adapter agent triages and implements its own repo's issues. All agents use the `claude-code` runtime and clone over HTTPS via `github-credentials`.
- **chore: update runtime subchart pins** — Resync the umbrella chart pins to the registry: claude-code 0.1.2 → 0.1.3 (openclaw, opencode already current).

## Test plan

- `make build` + `go test ./controllers/` pass (incl. new `TestBuildDexConfigYAML_DeterministicAgentOrder`).
- `helm lint` + `helm template --debug` pass for `charts/language-operator-runtimes` after the pin bump.
- Deployed via `make dev` to a live cluster: the `auth` Deployment stopped spawning new ReplicaSets (steady across a 40s window) and runs a single stable pod; the new example's seven agents reconcile and their `repository` init containers clone successfully over HTTPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)