### PR TITLE
fix: remove enterprise-only LiteLLM JWT auth from model gateway

### DIFF
--- a/components/model-gateway/generate-config.py
+++ b/components/model-gateway/generate-config.py
@@ -215,15 +215,6 @@ def generate_litellm_config(specs: List[Dict[str, Any]]) -> Dict[str, Any]:
         config["litellm_settings"] = merged_settings
 
     general_settings: Dict[str, Any] = {"background_health_checks": False}
-
-    # Enable JWT auth when an OIDC public key URL is provided.
-    # Set LITELLM_JWT_PUBLIC_KEY_URL to the JWKS endpoint of your OIDC provider
-    # (e.g. https://auth.my-cluster.example.com/keys for an embedded Dex instance).
-    jwt_key_url = os.environ.get("LITELLM_JWT_PUBLIC_KEY_URL", "").strip()
-    if jwt_key_url:
-        general_settings["enable_jwt_auth"] = True
-        general_settings["jwt_public_key_url"] = jwt_key_url
-
     config["general_settings"] = general_settings
 
     return config

--- a/src/controllers/languagecluster_controller.go
+++ b/src/controllers/languagecluster_controller.go
@@ -93,25 +93,6 @@ func (r *LanguageClusterReconciler) gatewayImage() string {
 	return "ghcr.io/language-operator/model-gateway:latest"
 }
 
-// gatewayEnv merges user-supplied env vars with operator-managed ones.
-// When spec.auth.enabled, LITELLM_JWT_PUBLIC_KEY_URL is injected so that the
-// model gateway enables LiteLLM JWT auth pointed at the cluster's Dex instance.
-func (r *LanguageClusterReconciler) gatewayEnv(cluster *langopv1alpha1.LanguageCluster, userEnv []corev1.EnvVar) []corev1.EnvVar {
-	issuer := dexIssuerURL(cluster)
-	if cluster.Spec.Auth == nil || !cluster.Spec.Auth.Enabled || issuer == "" {
-		return userEnv
-	}
-	jwtKeyURL := issuer + "/keys"
-	managed := corev1.EnvVar{Name: "LITELLM_JWT_PUBLIC_KEY_URL", Value: jwtKeyURL}
-	// User env takes precedence — don't override if they set it explicitly.
-	for _, e := range userEnv {
-		if e.Name == "LITELLM_JWT_PUBLIC_KEY_URL" {
-			return userEnv
-		}
-	}
-	return append([]corev1.EnvVar{managed}, userEnv...)
-}
-
 func (r *LanguageClusterReconciler) gatewayImagePullPolicy(cluster *langopv1alpha1.LanguageCluster) corev1.PullPolicy {
 	if cluster.Spec.Gateway != nil && cluster.Spec.Gateway.Deployment.ImagePullPolicy != "" {
 		return cluster.Spec.Gateway.Deployment.ImagePullPolicy
@@ -1236,7 +1217,7 @@ func (r *LanguageClusterReconciler) reconcileGateway(ctx context.Context, cluste
 							Args:            gatewayDeploy.Args,
 							ImagePullPolicy: r.gatewayImagePullPolicy(cluster),
 							Resources:       resources,
-							Env:             r.gatewayEnv(cluster, gatewayDeploy.Env),
+							Env:             gatewayDeploy.Env,
 							EnvFrom:         gatewayDeploy.EnvFrom,
 							VolumeMounts:    mounts,
 							Ports: []corev1.ContainerPort{


### PR DESCRIPTION
## Problem

Agents on auth-enabled clusters fail every model call with a 401 from the LiteLLM gateway:

```
openai.AuthenticationError: 401 - JWT Auth is an enterprise only feature.
You must be a LiteLLM Enterprise user to use this feature.
```

When a `LanguageCluster` has `spec.auth.enabled: true`, the cluster controller injected `LITELLM_JWT_PUBLIC_KEY_URL` into the gateway pod, which made the config generator set `enable_jwt_auth: true`. That flag is **LiteLLM Enterprise-only**, so the open-source proxy rejects every request. Agents are never issued a JWT, so this auth path never actually worked.

## Change

- Remove the `gatewayEnv` JWT injection in `languagecluster_controller.go` (gateway env now just passes through user-supplied `spec.gateway.deployment` env).
- Remove the `enable_jwt_auth` / `jwt_public_key_url` block in `generate-config.py`.

Dex and the per-agent oauth2-proxy **ingress** protection are untouched — only the broken gateway JWT path is removed.

## Posture

The in-cluster gateway is now unauthenticated at the LiteLLM layer, guarded by its NetworkPolicy. A `master_key`/virtual-key scheme is the OSS-supported path if gateway auth is wanted later (out of scope here).

## Verification

- `make build` + `go test ./controllers/...` pass; no generated-file drift.
- Deployed to `my-cluster` (`spec.auth.enabled: true`) via `make dev`: gateway env no longer has `LITELLM_JWT_PUBLIC_KEY_URL`, generated `/app/config.yaml` has no JWT keys, and a completion that previously 401'd now returns **HTTP 200**. Dex/ingress auth still running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)