### PR TITLE
feat: add deepagents runtime (umbrella chart, examples, guide)

### DIFF
--- a/charts/language-operator-runtimes/Chart.lock
+++ b/charts/language-operator-runtimes/Chart.lock
@@ -8,5 +8,8 @@ dependencies:
 - name: opencode
   repository: oci://ghcr.io/language-operator/charts
   version: 0.1.3
-digest: sha256:cebbd19b0bfc05c6da1cc8001186d2ed1fe30621a9215b4062b20ec0b15c2648
-generated: "2026-06-22T18:51:36.753799835-05:00"
+- name: deepagents
+  repository: oci://ghcr.io/language-operator/charts
+  version: 0.1.0
+digest: sha256:61eeb9031406f21ce10dfd4c45de8615e946fb06f1f697fa92aa42d93b0810bd
+generated: "2026-06-22T22:37:53.960053679-05:00"

--- a/charts/language-operator-runtimes/Chart.lock
+++ b/charts/language-operator-runtimes/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 0.1.3
 - name: deepagents
   repository: oci://ghcr.io/language-operator/charts
-  version: 0.1.0
-digest: sha256:61eeb9031406f21ce10dfd4c45de8615e946fb06f1f697fa92aa42d93b0810bd
-generated: "2026-06-22T22:37:53.960053679-05:00"
+  version: 0.1.1
+digest: sha256:f33a1259a71e64cdfdffb3ffc147eef3385682dbe16995abb82df39dd8af3e29
+generated: "2026-06-23T18:47:15.650675555-05:00"

--- a/charts/language-operator-runtimes/Chart.yaml
+++ b/charts/language-operator-runtimes/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: language-operator-runtimes
-description: Umbrella chart bundling the Language Operator runtimes (openclaw, opencode, claude-code) as subcharts
+description: Umbrella chart bundling the Language Operator runtimes (openclaw, opencode, claude-code, deepagents) as subcharts
 type: application
-version: 0.1.131
-appVersion: "0.1.131"
+version: 0.1.132
+appVersion: "0.1.132"
 keywords:
   - ai
   - llm
@@ -32,3 +32,7 @@ dependencies:
     version: "0.1.3"
     repository: oci://ghcr.io/language-operator/charts
     condition: opencode.enabled
+  - name: deepagents
+    version: "0.1.0"
+    repository: oci://ghcr.io/language-operator/charts
+    condition: deepagents.enabled

--- a/charts/language-operator-runtimes/Chart.yaml
+++ b/charts/language-operator-runtimes/Chart.yaml
@@ -33,6 +33,6 @@ dependencies:
     repository: oci://ghcr.io/language-operator/charts
     condition: opencode.enabled
   - name: deepagents
-    version: "0.1.0"
+    version: "0.1.1"
     repository: oci://ghcr.io/language-operator/charts
     condition: deepagents.enabled

--- a/charts/language-operator-runtimes/values.yaml
+++ b/charts/language-operator-runtimes/values.yaml
@@ -8,6 +8,7 @@
 #   - https://github.com/language-operator/claude-code-adapter
 #   - https://github.com/language-operator/openclaw-adapter
 #   - https://github.com/language-operator/opencode-adapter
+#   - https://github.com/language-operator/deepagents-adapter
 
 claude-code:
   # Install the claude-code LanguageAgentRuntime.
@@ -19,4 +20,8 @@ openclaw:
 
 opencode:
   # Install the opencode LanguageAgentRuntime.
+  enabled: true
+
+deepagents:
+  # Install the deepagents LanguageAgentRuntime.
   enabled: true

--- a/docs/guides/deepagents.md
+++ b/docs/guides/deepagents.md
@@ -1,0 +1,233 @@
+# Deploying deepagents
+
+[deepagents](https://github.com/langchain-ai/deepagents) is LangChain's framework for building a single, capable agent — planning, sub-agents, a virtual filesystem, and MCP tools. The `deepagents` runtime is bundled with Language Operator and installed automatically with the runtimes Helm chart.
+
+Unlike the coding-CLI runtimes ([Claude Code](claude-code.md), [OpenCode](opencode.md), [OpenClaw](openclaw.md)), deepagents is not an interactive terminal you drive. It is an **autonomous executor**: on startup it reads the agent's `spec.instructions`, runs that task once — streaming every step to **stdout** (so `kubectl logs` is the primary UI) and a live web view — then idles. The task *is* the `instructions` field.
+
+## Prerequisites
+
+- Language Operator [installed](../getting-started/installation.md), including the `language-operator-runtimes` chart (provides the `deepagents` runtime)
+- An LLM provider API key, or a local model endpoint (e.g. Ollama)
+
+## Instructions
+
+### Create a Cluster
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: langop.io/v1alpha1
+kind: LanguageCluster
+metadata:
+  name: demo-cluster
+spec:
+  domain: demo-cluster.<your-domain>
+EOF
+
+kubectl wait languagecluster/demo-cluster --for=condition=Ready --timeout=60s
+kubectl config set-context --current --namespace=demo-cluster
+```
+
+### Configure a Model
+
+deepagents reaches the model through the in-cluster LiteLLM gateway — it never holds a real provider key. Register a `LanguageModel` for the gateway to route to:
+
+=== "Anthropic"
+
+    ```bash
+    kubectl create secret generic anthropic-credentials \
+      --from-literal=api-key=sk-ant-your-key-here
+
+    kubectl apply -f - <<EOF
+    apiVersion: langop.io/v1alpha1
+    kind: LanguageModel
+    metadata:
+      name: claude-sonnet
+    spec:
+      provider: anthropic
+      modelName: claude-sonnet-4-5
+      apiKeySecretRef:
+        name: anthropic-credentials
+        key: api-key
+    EOF
+    ```
+
+=== "OpenAI"
+
+    ```bash
+    kubectl create secret generic openai-credentials \
+      --from-literal=api-key=sk-your-key-here
+
+    kubectl apply -f - <<EOF
+    apiVersion: langop.io/v1alpha1
+    kind: LanguageModel
+    metadata:
+      name: gpt-4o
+    spec:
+      provider: openai
+      modelName: gpt-4o
+      apiKeySecretRef:
+        name: openai-credentials
+        key: api-key
+    EOF
+    ```
+
+=== "Local Model"
+
+    Assumes Ollama is running in your cluster. No API key required.
+
+    ```bash
+    kubectl apply -f - <<EOF
+    apiVersion: langop.io/v1alpha1
+    kind: LanguageModel
+    metadata:
+      name: llama3
+    spec:
+      provider: openai-compatible
+      modelName: llama3.2
+      endpoint: http://ollama.default.svc.cluster.local:11434/v1
+    EOF
+    ```
+
+### Deploy a deepagents Agent
+
+A deepagents agent needs two things to do work: a `models` reference (the primary model) and `instructions` (the task it runs autonomously).
+
+=== "Anthropic"
+
+    ```bash
+    kubectl apply -f - <<EOF
+    apiVersion: langop.io/v1alpha1
+    kind: LanguageAgent
+    metadata:
+      name: researcher
+    spec:
+      runtime: deepagents
+      models:
+        - name: claude-sonnet
+      instructions: |
+        Research the public API of the "deepagents" Python library, then write
+        a concise, well-organized summary to /workspace/summary.md covering what
+        the library is and its main entry points. When the file is written, stop.
+    EOF
+    ```
+
+=== "OpenAI"
+
+    ```bash
+    kubectl apply -f - <<EOF
+    apiVersion: langop.io/v1alpha1
+    kind: LanguageAgent
+    metadata:
+      name: researcher
+    spec:
+      runtime: deepagents
+      models:
+        - name: gpt-4o
+      instructions: |
+        Research the public API of the "deepagents" Python library, then write
+        a concise, well-organized summary to /workspace/summary.md covering what
+        the library is and its main entry points. When the file is written, stop.
+    EOF
+    ```
+
+=== "Local Model"
+
+    ```bash
+    kubectl apply -f - <<EOF
+    apiVersion: langop.io/v1alpha1
+    kind: LanguageAgent
+    metadata:
+      name: researcher
+    spec:
+      runtime: deepagents
+      models:
+        - name: llama3
+      instructions: |
+        Research the public API of the "deepagents" Python library, then write
+        a concise, well-organized summary to /workspace/summary.md covering what
+        the library is and its main entry points. When the file is written, stop.
+    EOF
+    ```
+
+!!! note
+
+    Without `instructions` the agent comes up healthy but idles — there is no task to run. Without a `models` reference it cannot resolve a model and idles as well. Both are reported in the pod logs on startup.
+
+### Verify
+
+```bash
+kubectl get languageagents
+kubectl get pods -w
+```
+
+Wait for the pod to reach `Running` and the LanguageAgent to show `Ready=True`.
+
+### Watch it run
+
+The agent starts working as soon as the pod is `Running` — there is nothing to log into. The run streams to stdout:
+
+```bash
+kubectl logs -f deploy/researcher
+```
+
+You'll see the agent plan, act, and (for this task) write `/workspace/summary.md`. When the task finishes it reports `completed` and idles.
+
+### Connect to the live view
+
+For a browser view of the same stream plus human-in-the-loop controls, port-forward the service:
+
+```bash
+kubectl port-forward svc/researcher 8080:8080
+# open http://localhost:8080
+```
+
+The thin server exposes `GET /` (live UI), `GET /events` (SSE), `GET /state` (status + any pending interrupt), `POST /resume`, and `POST /restart`. `GET /health` backs the pod's probes.
+
+## Human-in-the-loop
+
+By default the runtime pauses before **side-effecting** tools — the built-in `write_file`/`edit_file` plus every MCP tool — and waits for approval. Read-only operations (`ls`/`read_file`) never pause. While paused the agent reports `interrupted`; approve or reject from the live view at `/`, or with `POST /resume`.
+
+Tune the policy with the `HITL_TOOLS` environment variable:
+
+| `HITL_TOOLS` | Behavior |
+|---|---|
+| _unset_ (default) | Pause before `write_file`/`edit_file` and all MCP tools |
+| `none` or `""` | Never pause — fully autonomous |
+| `*` | Pause before every tool (built-in writers + all MCP tools) |
+| `write_file,edit_file,…` | Pause only before the named tools |
+
+```yaml
+spec:
+  runtime: deepagents
+  deployment:
+    env:
+      - name: HITL_TOOLS
+        value: "none"   # hands-off; the task runs end to end
+```
+
+## Adding tools
+
+Reference any [`LanguageTool`](../components/tools.md) and the operator resolves its MCP endpoint into the agent; deepagents loads it as a tool automatically:
+
+```yaml
+spec:
+  runtime: deepagents
+  models:
+    - name: claude-sonnet
+  tools:
+    - name: context7
+  instructions: |
+    Use the context7 tool to look up the current API, then …
+```
+
+## What the Operator Created
+
+| Resource | Name | Purpose |
+|---|---|---|
+| Namespace | `demo-cluster` | Isolated workload namespace |
+| Deployment | `researcher` | Runs the deepagents container |
+| Service | `researcher` | ClusterIP on port 8080 |
+| NetworkPolicy | `researcher` | Allows inbound from other agents in this namespace |
+| PVC | `researcher-workspace` | 10Gi persistent workspace (agent files + checkpoint DB) |
+| ConfigMap | `researcher-agent` | Injected at `/etc/agent/config.yaml` |
+```

--- a/examples/agents/deepagents/README.md
+++ b/examples/agents/deepagents/README.md
@@ -1,0 +1,101 @@
+# agents/deepagents
+
+Deploys a single [deepagents](https://github.com/langchain-ai/deepagents) agent that
+**autonomously runs a task** — here, researching a library through the `context7` MCP tool
+and writing a cited summary to its workspace.
+
+Unlike the coding-CLI runtimes (claude-code, opencode, openclaw), deepagents is a *framework*
+runtime: it is not an interactive terminal you drive. On startup it reads its
+`spec.instructions`, builds a deep agent (planning, sub-agents, a `/workspace` filesystem,
+and any referenced MCP tools) pointed at the cluster gateway, runs the task once, then idles.
+**`kubectl logs` is the primary UI** — every step streams to stdout. A thin web view at `/`
+mirrors the stream and adds Approve/Reject buttons when human-in-the-loop is enabled.
+
+Because the model is reached through the cluster gateway, this example references a
+`LanguageModel` by name (`claude-sonnet` by default) rather than bundling it — register the
+model separately first (see [models/anthropic](../../models/anthropic/)). The `context7` tool
+*is* bundled here so the example is self-contained.
+
+## Prerequisites
+
+- Language Operator [installed](https://langop.io/docs/getting-started/installation/)
+- `language-operator-runtimes` chart installed (provides the `deepagents` runtime)
+- `kubectl` configured for your cluster
+- `envsubst` (`brew install gettext` on macOS, pre-installed on most Linux distros)
+- A `LanguageCluster` already applied in the target namespace (see [clusters/basic](../../clusters/basic/))
+- A `LanguageModel` named `claude-sonnet` registered in that namespace (see [models/anthropic](../../models/anthropic/))
+
+## Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `CLUSTER_NAME` | yes | — | Namespace of the target LanguageCluster |
+| `AGENT_NAME` | no | `researcher` | Name of the LanguageAgent |
+| `MODEL_NAME` | no | `claude-sonnet` | Name of the LanguageModel CR the agent references (must already exist) |
+| `WORKSPACE_SIZE` | no | `10Gi` | Persistent workspace PVC size |
+
+## Install
+
+Register a model first, then deploy the agent + tool:
+
+```bash
+# 1. register the model (latest Sonnet + Opus) and its credentials secret
+CLUSTER_NAME=my-cluster ANTHROPIC_API_KEY=sk-ant-... bash examples/models/anthropic/install.sh
+
+# 2. deploy the deepagents agent and the context7 tool
+CLUSTER_NAME=my-cluster bash examples/agents/deepagents/install.sh
+```
+
+Dry-run (prints rendered YAML):
+```bash
+CLUSTER_NAME=my-cluster bash examples/agents/deepagents/install.sh --dry-run
+```
+
+## Watch it run
+
+The agent starts working as soon as the pod is `Running` — there is nothing to log into.
+
+```bash
+kubectl logs -n my-cluster -f deploy/researcher
+```
+
+You'll see the agent plan, call the `context7` tool, and write
+`/workspace/deepagents-summary.md`. When the task finishes it reports `completed` and idles.
+
+For the live web view (status, streaming output, and HITL controls):
+
+```bash
+kubectl port-forward -n my-cluster svc/researcher 8080:8080
+# open http://localhost:8080
+```
+
+## Human-in-the-loop
+
+By default the runtime pauses before side-effecting tools (`write_file`/`edit_file` and every
+MCP tool) and waits for approval. This example sets `HITL_TOOLS=none` in the agent's
+`deployment.env` for a hands-off first run. To require approvals instead, remove that env var
+(or set it to `"*"`); the run will pause as `interrupted`, and you approve/reject from the web
+view at `/` or via `POST /resume`.
+
+## What's created
+
+- `LanguageAgent/researcher` — the agent CR
+- `LanguageTool/context7` — the bundled MCP documentation tool
+- `Deployment/researcher` — runs the deepagents container on port 8080
+- `Service/researcher` — exposes the live view / HITL endpoints
+- `NetworkPolicy/researcher` — operator-managed; in-cluster access to the gateway and tool
+- `PersistentVolumeClaim/researcher` — workspace at `/workspace` (agent files + checkpoint DB)
+- `ConfigMap/researcher-config` — assembled agent configuration
+
+The agent itself needs no external egress — it reaches the model through the in-cluster gateway
+and the tool through its in-cluster MCP service.
+
+## Teardown
+
+```bash
+kubectl delete languageagent researcher -n my-cluster
+kubectl delete languagetool context7 -n my-cluster
+```
+
+The referenced `LanguageModel` and its secret are managed separately — tear them down with
+[models/anthropic](../../models/anthropic/) if you no longer need them.

--- a/examples/agents/deepagents/install.sh
+++ b/examples/agents/deepagents/install.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Usage: CLUSTER_NAME=my-cluster bash install.sh [--dry-run]
+#
+# Requires a LanguageModel named "$MODEL_NAME" to already exist in the cluster
+# namespace — deploy one first, e.g. examples/models/anthropic (registers
+# claude-sonnet / claude-opus and their credentials secret).
+set -euo pipefail
+
+: "${CLUSTER_NAME:?CLUSTER_NAME is required — set it to the name of your LanguageCluster}"
+export AGENT_NAME="${AGENT_NAME:-researcher}"
+export CLUSTER_NAME
+export MODEL_NAME="${MODEL_NAME:-claude-sonnet}"
+export WORKSPACE_SIZE="${WORKSPACE_SIZE:-10Gi}"
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+for f in "$DIR"/*.yaml; do
+    envsubst < "$f" > "$TMPDIR/$(basename "$f")"
+done
+
+if $DRY_RUN; then
+    kubectl kustomize "$TMPDIR"
+    exit 0
+fi
+
+kubectl kustomize "$TMPDIR" | kubectl apply -f -

--- a/examples/agents/deepagents/kustomization.yaml
+++ b/examples/agents/deepagents/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - languagetool.context7.yaml
+  - languageagent.deepagents.yaml

--- a/examples/agents/deepagents/languageagent.deepagents.yaml
+++ b/examples/agents/deepagents/languageagent.deepagents.yaml
@@ -1,0 +1,35 @@
+apiVersion: langop.io/v1alpha1
+kind: LanguageAgent
+metadata:
+  name: ${AGENT_NAME}
+  namespace: ${CLUSTER_NAME}
+spec:
+  runtime: deepagents
+  # deepagents is an autonomous executor: it runs these instructions once on
+  # startup (planning, sub-agents, a /workspace filesystem, MCP tools), streams
+  # every step to stdout (watch with `kubectl logs`), then idles. There is no
+  # prompt to type into — the task IS spec.instructions.
+  instructions: |
+    Research the public API of the "deepagents" Python library using the
+    context7 documentation tool. Then write a concise, well-organized summary
+    to /workspace/deepagents-summary.md covering: what the library is, the
+    create_deep_agent entry point and its key arguments, and how to attach MCP
+    tools. Cite the documentation sources you used. When the file is written,
+    stop.
+  # The primary model. Resolved through the in-cluster LiteLLM gateway — the
+  # agent never holds a real provider key. Must already exist in the namespace.
+  models:
+    - name: ${MODEL_NAME}
+  tools:
+    - name: context7
+  workspace:
+    # deepagents writes its files (and its checkpoint DB) here; survives restarts.
+    size: ${WORKSPACE_SIZE}
+  deployment:
+    env:
+      # Human-in-the-loop is ON by default: the agent pauses before side-effecting
+      # tools (write_file/edit_file + every MCP tool) and waits for POST /resume.
+      # For a hands-off first run we disable it so the task completes end-to-end.
+      # Remove this (or set "*") to require Approve/Reject in the live UI at `/`.
+      - name: HITL_TOOLS
+        value: "none"

--- a/examples/agents/deepagents/languagetool.context7.yaml
+++ b/examples/agents/deepagents/languagetool.context7.yaml
@@ -1,0 +1,41 @@
+apiVersion: langop.io/v1alpha1
+kind: LanguageTool
+metadata:
+  name: context7
+  namespace: ${CLUSTER_NAME}
+spec:
+  # Context7 ships as a stdio MCP server. transport=stdio tells the operator to run it under a
+  # pinned, persistent stdio→Streamable-HTTP bridge (one long-lived child) and serve /mcp on
+  # spec.port. The operator injects the bridge, a writable cache + /tmp, and the readiness probe.
+  transport: stdio
+  port: 8080
+  stdio:
+    command:
+      - npx
+      - -y
+      - "@upstash/context7-mcp"
+  deployment:
+    # The Node MCP server grows past the operator's 512Mi default and gets OOMKilled;
+    # give it 1Gi of headroom.
+    resources:
+      limits:
+        memory: 1Gi
+    env:
+      # The API key is optional: without it Context7 still works, just at a lower rate limit.
+      # optional:true lets the pod start when the secret is absent (install without an API key).
+      - name: CONTEXT7_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: context7-mcp-credentials
+            key: api-key
+            optional: true
+  # The operator's default tool policy denies external egress. Context7 needs public HTTPS
+  # twice over: npx fetches the server package from the npm registry at boot, and the server
+  # calls Context7's API at runtime. Without this the pod can't start.
+  networkPolicies:
+    egress:
+      - to:
+          - cidr: "0.0.0.0/0"
+        ports:
+          - port: 443
+            protocol: TCP

--- a/examples/language-operator-team/README.md
+++ b/examples/language-operator-team/README.md
@@ -3,7 +3,7 @@
 Deploys the full Language Operator engineering team into an existing LanguageCluster: the
 [development-team](../development-team/) (a supervisor that triages the core repo's issues into
 priority queues + three workers that implement them) **plus** one self-contained maintainer
-agent for each of the three sister adapter repositories.
+agent for each of the four sister adapter repositories.
 
 Each agent declares its repo via `spec.repository`, so the operator clones it into the agent's
 workspace on init and starts the runtime inside the checkout (exposed as `$AGENT_REPO_DIR`) — no
@@ -22,6 +22,7 @@ worker-2 (engineer persona)  ← queue/2: backlog (chores, docs, cleanup)
 adapter-claude-code (engineer persona)  → language-operator/claude-code-adapter
 adapter-openclaw    (engineer persona)  → language-operator/openclaw-adapter
 adapter-opencode    (engineer persona)  → language-operator/opencode-adapter
+adapter-deepagents  (engineer persona)  → language-operator/deepagents-adapter
 ```
 
 Unlike the queue-based core workers, each `adapter-*` agent owns a single repo end to end: it
@@ -29,11 +30,11 @@ runs its own triage+implement loop (pick the highest-priority open, non-`in-prog
 implement → PR → merge → loop). A single agent per repo serializes naturally, so no queues or
 supervisor are needed for the adapters.
 
-All seven agents reference the [`context7`](../tools/context7/) `LanguageTool`, giving them
+All eight agents reference the [`context7`](../tools/context7/) `LanguageTool`, giving them
 up-to-date, version-specific library documentation over MCP so they stop coding against stale or
 hallucinated APIs.
 
-> The three `adapter-*` agents hardcode their `spec.repository.url` to the
+> The four `adapter-*` agents hardcode their `spec.repository.url` to the
 > `language-operator/<name>-adapter` repos. Edit those URLs in
 > `languageagent.adapter-*.yaml` if you work against forks.
 
@@ -45,14 +46,14 @@ hallucinated APIs.
 - `envsubst` (`brew install gettext` on macOS, pre-installed on most Linux distros)
 - A `LanguageCluster` already applied in the target namespace (see [clusters/basic](../clusters/basic/))
 - A Claude account (Pro, Max, Team, or Enterprise)
-- A GitHub personal access token with `repo` and `issues` scopes — used both to authenticate the clones (`spec.repository.secretRef`) and for the agents' `gh` operations. The same token must have access to the core repo **and** the three adapter repos.
+- A GitHub personal access token with `repo` and `issues` scopes — used both to authenticate the clones (`spec.repository.secretRef`) and for the agents' `gh` operations. The same token must have access to the core repo **and** the four adapter repos.
 
 ## Variables
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `CLUSTER_NAME` | yes | — | Namespace of the target LanguageCluster |
-| `GITHUB_TOKEN` | yes | — | GitHub PAT (`repo`, `issues` scopes) — written to `github-credentials/token` secret; used for the clones and for `gh`. Needs access to the core repo and all three adapter repos. |
+| `GITHUB_TOKEN` | yes | — | GitHub PAT (`repo`, `issues` scopes) — written to `github-credentials/token` secret; used for the clones and for `gh`. Needs access to the core repo and all four adapter repos. |
 | `PROJECT_REPOSITORY` | yes | — | Clone URL of the **core** repo the supervisor/workers work on (e.g. `https://github.com/language-operator/language-operator.git`). Cloned into each core agent's workspace via `spec.repository`. The adapter agents hardcode their own repo URLs. |
 | `PROJECT_NAME` | no | repo basename (minus `.git`) | Human-readable project name used in the core agents' prompts (e.g. `Language Operator`) |
 | `ANTHROPIC_API_KEY` | no | — | If set, written to `anthropic-credentials/api-key` and injected as `ANTHROPIC_API_KEY` on every agent (API-key billing). |
@@ -88,7 +89,7 @@ To mint a long-lived OAuth token (subscription billing, no browser needed): run 
 ```bash
 kubectl port-forward -n my-cluster svc/supervisor 8080:8080
 # open http://localhost:8080, run /login
-# ... repeat for worker-0/1/2 and adapter-claude-code/openclaw/opencode
+# ... repeat for worker-0/1/2 and adapter-claude-code/openclaw/opencode/deepagents
 ```
 
 ## What's created
@@ -107,6 +108,7 @@ kubectl port-forward -n my-cluster svc/supervisor 8080:8080
 - `LanguageAgent/adapter-claude-code` — owns `claude-code-adapter`; 10Gi workspace; uses `context7`
 - `LanguageAgent/adapter-openclaw` — owns `openclaw-adapter`; 10Gi workspace; uses `context7`
 - `LanguageAgent/adapter-opencode` — owns `opencode-adapter`; 10Gi workspace; uses `context7`
+- `LanguageAgent/adapter-deepagents` — owns `deepagents-adapter`; 10Gi workspace; uses `context7`
 
 Each `LanguageAgent` also produces a `Deployment`, `Service`, `NetworkPolicy`, `PersistentVolumeClaim`, and `ConfigMap`. Because each agent sets `spec.repository`, the operator injects a `repository` init container that clones the repo into the workspace (authenticated with `github-credentials`) and points the runtime's working directory at the checkout via `$AGENT_REPO_DIR`.
 

--- a/examples/language-operator-team/kustomization.yaml
+++ b/examples/language-operator-team/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - languageagent.adapter-claude-code.yaml
   - languageagent.adapter-openclaw.yaml
   - languageagent.adapter-opencode.yaml
+  - languageagent.adapter-deepagents.yaml

--- a/examples/language-operator-team/languageagent.adapter-deepagents.yaml
+++ b/examples/language-operator-team/languageagent.adapter-deepagents.yaml
@@ -1,0 +1,104 @@
+apiVersion: langop.io/v1alpha1
+kind: LanguageAgent
+metadata:
+  name: adapter-deepagents
+  namespace: ${CLUSTER_NAME}
+spec:
+  runtime: claude-code
+  persona: engineer
+  tools:
+    - name: context7
+  instructions: |
+    You are the maintainer agent for the deepagents-adapter repository — the
+    sister repo that builds the combined deepagents runtime image and the
+    `deepagents` runtime Helm chart for Language Operator. It is the project's
+    first framework runtime: a Python FastAPI service that autonomously runs an
+    agent's instructions. You own this single repo end to end: you both triage
+    and implement its open issues.
+
+    You start in a checkout of deepagents-adapter (the operator clones it into
+    your workspace and opens your shell there), so `gh` and git operate on the
+    repo without any setup.
+
+    On each invocation:
+
+    1. List open issues that are not labelled "in-progress". Pick the single
+       highest-priority one (urgent bugs and failing CI first, then features,
+       then chores/docs). If there are none, report idle and stop.
+
+    2. Read the issue thoroughly (title, body, comments).
+
+    3. Investigate whether the issue is valid. If invalid (misuse of a feature,
+       duplicate, out of date), comment with the rationale and close it, then
+       loop back to step 1. Otherwise continue.
+
+    4. Label the issue "in-progress". Create a branch off the main branch for
+       your changes.
+
+    5. Implement the change. Follow project conventions documented in the repo
+       (e.g. CLAUDE.md, README, CONTRIBUTING) when present. This is a Python
+       repo (uv + pytest) that ships a container image and a Helm chart — when
+       you touch any of them, lint/test/build the way the repo documents.
+
+    6. Run the project's tests. Add new tests as appropriate.
+
+    7. Commit with a conventional one-line message (feat:, fix:, chore:, etc.)
+       and push the branch.
+
+    8. Open a PR with a title matching the commit and body "Closes #<N>".
+
+    9. Poll CI until all checks complete. Push fixups until everything is green.
+
+    10. Squash-merge the PR and delete the branch.
+
+    11. Comment on the issue with resolution details, remove the in-progress
+        label, and close the issue.
+
+    12. Loop: go back to step 1 until there is no actionable work left.
+
+    Use `gh` for all GitHub operations. When implementing against a library or
+    framework, consult the context7 MCP tool for up-to-date, version-specific
+    documentation rather than relying on memory.
+  repository:
+    url: https://github.com/language-operator/deepagents-adapter.git
+    secretRef:
+      name: github-credentials
+  networkPolicies:
+    egress:
+      - to:
+          - cidr: "0.0.0.0/0"
+        ports:
+          - port: 443
+            protocol: TCP
+          - port: 80
+            protocol: TCP
+  workspace:
+    size: 10Gi
+  deployment:
+    # Adapter agents compile and test the repo and build container/chart
+    # artifacts — peaks in the multi-GiB range and wants several cores.
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: 4000m
+        memory: 6Gi
+    env:
+      - name: GITHUB_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: github-credentials
+            key: token
+      - name: ANTHROPIC_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: anthropic-credentials
+            key: api-key
+            optional: true
+      - name: CLAUDE_CODE_OAUTH_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: claude-code-oauth
+            key: token
+            optional: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
         - OpenClaw: guides/openclaw.md
         - OpenCode: guides/opencode.md
         - Claude Code: guides/claude-code.md
+        - deepagents: guides/deepagents.md
         - Custom Agents: guides/custom-agents.md
   - CRD Reference: api/reference.md
   - Development:


### PR DESCRIPTION
## Summary

Integrates the new **deepagents** runtime — Language Operator's first *framework* runtime — built in the sister [`deepagents-adapter`](https://github.com/language-operator/deepagents-adapter) repo and published as `oci://ghcr.io/language-operator/charts/deepagents`. Unlike the coding-CLI runtimes (claude-code/opencode/openclaw), deepagents is an **autonomous executor**: on startup it runs the agent's `spec.instructions` once, streaming to stdout, with optional human-in-the-loop.

## Changes

- **Runtimes umbrella chart** — add `deepagents` as a fourth subchart (toggled via `deepagents.enabled`), regenerate `Chart.lock`, bump the umbrella version.
- **`examples/agents/deepagents/`** — a self-contained example (agent + bundled `context7` MCP tool) demonstrating an autonomous research task.
- **`examples/language-operator-team/`** — add an `adapter-deepagents` maintainer agent for the fourth sister adapter repo, mirroring the existing `adapter-*` agents; update kustomization + README.
- **`docs/guides/deepagents.md`** — a deploy guide centered on the autonomous-executor model (watch via `kubectl logs`, the live view, the `HITL_TOOLS` policy, adding MCP tools); wired into the mkdocs nav.

## Verification

- `deepagents` chart confirmed published to the OCI registry; `helm lint` + `helm template` render `LanguageAgentRuntime/deepagents` correctly.
- `kubectl kustomize` renders both the standalone example and the team example (now 8 agents).
- `make docs-build` (`mkdocs build --strict`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)