### PR TITLE
feat(examples): add R1 agent-memory example (server-memory, sidecar)

### DIFF
--- a/examples/tools/memory/README.md
+++ b/examples/tools/memory/README.md
@@ -1,0 +1,114 @@
+# tools/memory
+
+An agent that **remembers across restarts** — with zero extra infrastructure.
+
+This is **Rung 1** of the [tool-layer example curriculum](https://github.com/language-operator/language-operator/issues/890).
+It registers the official [knowledge-graph memory server](https://www.npmjs.com/package/@modelcontextprotocol/server-memory)
+(`@modelcontextprotocol/server-memory`) as a `LanguageTool` and attaches it to a demo agent.
+
+## The concept
+
+The memory server is a **stdio** MCP server, so the operator runs it under a pinned
+stdio→Streamable-HTTP bridge — you don't wire up a bridge yourself. The one thing that makes this
+example special is `spec.deploymentMode: sidecar`:
+
+- In the default **`service`** mode a tool runs as a shared `Deployment`, and the bridge's scratch
+  space is an ephemeral `EmptyDir` — gone on every restart.
+- In **`sidecar`** mode the tool container is injected **into the agent's own pod**, where it can
+  see the agent's `/workspace` PVC.
+
+Point the memory file at that PVC (`MEMORY_FILE_PATH=/workspace/.memory/memory.jsonl`) and the
+knowledge graph outlives any single pod. Tell the agent some facts, delete its pod, and after it
+reschedules it still recalls them — no database, no StatefulSet, no external store.
+
+> **Gotcha — sidecars need a workspace.** A sidecar tool can only persist if the agent has a
+> `/workspace` PVC. The demo agent enables one (`spec.workspace`, default-enabled). If you strip the
+> workspace, `MEMORY_FILE_PATH` lands on ephemeral storage and the demo no longer survives restarts.
+
+## Prerequisites
+
+- Language Operator [installed](https://langop.io/docs/getting-started/installation/)
+- `kubectl` configured for your cluster
+- `envsubst` (`brew install gettext` on macOS, pre-installed on most Linux distros)
+- A `LanguageCluster` already applied in the target namespace (see [clusters/basic](../../clusters/basic/))
+- A `LanguageModel` in that cluster for the agent to use (see [models/anthropic](../../models/anthropic/))
+- Credentials for the `claude-code` runtime — an `anthropic-credentials` secret (`api-key`) **or**
+  a `claude-code-oauth` secret (`token`) in the cluster namespace
+
+## Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `CLUSTER_NAME` | yes | — | Namespace of the target LanguageCluster |
+| `MODEL_NAME` | yes | — | Name of a LanguageModel the demo agent should use |
+| `TOOL_NAME` | no | `memory` | Name of the LanguageTool CR (the name the agent references) |
+| `AGENT_NAME` | no | `memory-demo` | Name of the demo LanguageAgent CR |
+| `WORKSPACE_SIZE` | no | `10Gi` | Size of the agent's `/workspace` PVC |
+
+> **Egress:** the tool manifest grants outbound HTTPS (`0.0.0.0/0:443`) because `npx` fetches the
+> server package from the npm registry at boot. The server itself makes no network calls — it only
+> reads and writes the local memory file. The operator's default tool policy denies external egress,
+> so this boot-time rule is required.
+
+## Install
+
+```bash
+CLUSTER_NAME=my-cluster MODEL_NAME=my-model bash examples/tools/memory/install.sh
+```
+
+Dry-run (prints rendered YAML, applies nothing):
+```bash
+CLUSTER_NAME=my-cluster MODEL_NAME=my-model bash examples/tools/memory/install.sh --dry-run
+```
+
+## What's created
+
+- `LanguageTool/memory` — the MCP tool CR (`transport: stdio`, `deploymentMode: sidecar`)
+- `LanguageAgent/memory-demo` — a `claude-code` agent that references the tool and a model, with a
+  `/workspace` PVC for the sidecar to write to
+
+No secret and no backend are created — the memory server has no credentials.
+
+Once the tool reaches `Ready`, the operator's MCP handshake populates `status.toolSchemas`, which
+proves the server speaks MCP through the bridge:
+
+```bash
+kubectl get languagetool memory -n my-cluster -o jsonpath='{.status.toolSchemas}' ; echo
+```
+
+The memory container runs **inside the agent pod** (sidecar). Confirm it and its `/workspace` mount:
+
+```bash
+kubectl get pod -n my-cluster -l app.kubernetes.io/name=memory-demo,langop.io/component=agent \
+  -o jsonpath='{.items[0].spec.containers[*].name}' ; echo
+```
+
+## The demo: memory that survives a pod delete
+
+1. **Tell the agent some facts.** Talk to the `memory-demo` agent however your cluster exposes it
+   and give it 2–3 things to remember, e.g. *"My name is James, my favorite language is Go, and our
+   staging cluster is called `aurora`."* The agent records them via the memory tool.
+
+2. **Delete the agent pod.**
+   ```bash
+   kubectl delete pod -n my-cluster -l app.kubernetes.io/name=memory-demo,langop.io/component=agent
+   ```
+   The Deployment reschedules a fresh pod. The new pod re-attaches the same `/workspace` PVC, so the
+   `memory.jsonl` written earlier is still there.
+
+3. **Ask it what it remembers.** *"What's my name and favorite language?"* The agent queries the
+   memory tool and answers correctly — proof the state survived on the PVC, not in pod memory.
+
+## Teardown
+
+```bash
+kubectl delete languageagent memory-demo -n my-cluster
+kubectl delete languagetool memory -n my-cluster
+```
+
+Deleting the agent also removes its `/workspace` PVC (and the stored memory) per the cluster's
+reclaim policy.
+
+---
+
+Part of the [tool-layer example curriculum (R1–R7)](https://github.com/language-operator/language-operator/issues/890).

--- a/examples/tools/memory/install.sh
+++ b/examples/tools/memory/install.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Registers the official knowledge-graph memory server as a sidecar LanguageTool and deploys a
+# demo claude-code agent that uses it. The sidecar persists its state on the agent's /workspace
+# PVC, so memory survives pod restarts with no external store.
+#
+# Usage: CLUSTER_NAME=my-cluster MODEL_NAME=my-model bash install.sh [--dry-run]
+set -euo pipefail
+
+: "${CLUSTER_NAME:?CLUSTER_NAME is required — set it to the name of your LanguageCluster}"
+: "${MODEL_NAME:?MODEL_NAME is required — set it to the name of a LanguageModel in that cluster}"
+export CLUSTER_NAME
+export MODEL_NAME
+export TOOL_NAME="${TOOL_NAME:-memory}"
+export AGENT_NAME="${AGENT_NAME:-memory-demo}"
+export WORKSPACE_SIZE="${WORKSPACE_SIZE:-10Gi}"
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Restrict substitution to our placeholders so any literal $VARs in the manifests survive to be
+# expanded inside the container at runtime.
+for f in "$DIR"/*.yaml; do
+    envsubst '$CLUSTER_NAME $MODEL_NAME $TOOL_NAME $AGENT_NAME $WORKSPACE_SIZE' < "$f" > "$TMPDIR/$(basename "$f")"
+done
+
+if $DRY_RUN; then
+    kubectl kustomize "$TMPDIR"
+    exit 0
+fi
+
+# No secret, no backend — the memory server has no credentials and writes only to /workspace.
+kubectl kustomize "$TMPDIR" | kubectl apply -f -

--- a/examples/tools/memory/kustomization.yaml
+++ b/examples/tools/memory/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - languagetool.memory.yaml
+  - languageagent.memory-demo.yaml

--- a/examples/tools/memory/languageagent.memory-demo.yaml
+++ b/examples/tools/memory/languageagent.memory-demo.yaml
@@ -1,0 +1,53 @@
+apiVersion: langop.io/v1alpha1
+kind: LanguageAgent
+metadata:
+  name: ${AGENT_NAME}
+  namespace: ${CLUSTER_NAME}
+spec:
+  runtime: claude-code
+  # Referencing the tool injects its sidecar into this pod and wires the MCP endpoint into the
+  # agent via MCP_SERVERS and /etc/agent/config.yaml.
+  tools:
+    - name: ${TOOL_NAME}
+  models:
+    - name: ${MODEL_NAME}
+  instructions: |
+    You have a persistent memory backed by the "memory" MCP tool (a knowledge graph
+    that survives restarts).
+
+    - When the user tells you a fact about themselves, their projects, or their
+      preferences, record it with the memory tool (create entities and relations,
+      add observations).
+    - When the user asks what you remember, query the memory tool and answer from
+      what you find there — do not guess.
+    - Treat the memory as the source of truth across conversations and restarts.
+  # Sidecar tools require the agent to have a workspace: the memory server writes its knowledge
+  # graph to /workspace (default-enabled). This PVC is what makes the memory survive a pod
+  # restart.
+  workspace:
+    size: ${WORKSPACE_SIZE}
+  networkPolicies:
+    egress:
+      - to:
+          - cidr: "0.0.0.0/0"
+        ports:
+          - port: 443
+            protocol: TCP
+          - port: 80
+            protocol: TCP
+  deployment:
+    env:
+      # The claude-code runtime authenticates with either an Anthropic API key or an OAuth token.
+      # Both are optional here so the manifest applies cleanly; supply whichever your cluster uses.
+      - name: ANTHROPIC_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: anthropic-credentials
+            key: api-key
+            optional: true
+      - name: CLAUDE_CODE_OAUTH_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: claude-code-oauth
+            key: token
+            optional: true

--- a/examples/tools/memory/languagetool.memory.yaml
+++ b/examples/tools/memory/languagetool.memory.yaml
@@ -1,0 +1,43 @@
+apiVersion: langop.io/v1alpha1
+kind: LanguageTool
+metadata:
+  name: ${TOOL_NAME}
+  namespace: ${CLUSTER_NAME}
+spec:
+  # The official knowledge-graph memory server ships as a stdio MCP server. transport=stdio tells
+  # the operator to run it under a pinned, persistent stdio→Streamable-HTTP bridge (one long-lived
+  # child) and serve /mcp on spec.port. The operator injects the bridge, a writable cache + /tmp,
+  # and the readiness probe — no supergateway flags or HOME env needed here.
+  transport: stdio
+  port: 8080
+  # The whole point of this example: sidecar mode injects the tool container into the agent's pod,
+  # where it can see the agent's own /workspace PVC. That is what lets memory survive a pod
+  # restart with zero extra infrastructure — no StatefulSet, no external store.
+  deploymentMode: sidecar
+  stdio:
+    command:
+      - npx
+      - -y
+      - "@modelcontextprotocol/server-memory"
+  deployment:
+    # The Node MCP server grows past the operator's 512Mi default and gets OOMKilled;
+    # give it 1Gi of headroom.
+    resources:
+      limits:
+        memory: 1Gi
+    env:
+      # Persist the knowledge graph on the agent's /workspace PVC. Anywhere outside /workspace is
+      # ephemeral and would be lost on restart — defeating the demo. The sidecar creates the
+      # .memory directory on first write.
+      - name: MEMORY_FILE_PATH
+        value: /workspace/.memory/memory.jsonl
+  # The operator's default tool policy denies external egress. npx fetches the server package from
+  # the npm registry at boot over HTTPS; without this the sidecar can't start. There is no runtime
+  # egress — the server only reads and writes the local file.
+  networkPolicies:
+    egress:
+      - to:
+          - cidr: "0.0.0.0/0"
+        ports:
+          - port: 443
+            protocol: TCP


### PR DESCRIPTION
Adds `examples/tools/memory/` — Rung 1 of the tool-layer example curriculum (#890).

An agent that **remembers across pod restarts** with zero extra infrastructure: the official knowledge-graph memory server (`@modelcontextprotocol/server-memory`) runs as a **sidecar** so its state lives on the agent's own `/workspace` PVC.

## What's added (the standard quartet + demo agent)
- `languagetool.memory.yaml` — stdio tool, `deploymentMode: sidecar`, `MEMORY_FILE_PATH=/workspace/.memory/memory.jsonl`, 1Gi limit, boot-only `0.0.0.0/0:443` egress. No secret, no backend.
- `languageagent.memory-demo.yaml` — `claude-code` agent referencing the tool + a model, workspace-enabled, with the optional anthropic/oauth credential env.
- `kustomization.yaml`, `install.sh` (context7 no-secret pattern), `README.md` covering the concept, prereqs, the delete-pod E2E demo, and teardown; links back to #890.

## Verification
- `bash install.sh --dry-run` renders valid YAML; `kubectl kustomize` is clean.
- `bash -n install.sh` passes; pod-selector labels in the README verified against `GetCommonLabels` (`app.kubernetes.io/name` + `langop.io/component=agent`).
- No CRD/operator/Go changes — pure example, per the #890 hard constraint.

Closes #891