### PR TITLE
feat(examples): R2 — semantic memory with local embeddings (mcp-server-qdrant, embedded)

### DIFF
--- a/examples/tools/qdrant/README.md
+++ b/examples/tools/qdrant/README.md
@@ -1,0 +1,136 @@
+# tools/qdrant
+
+An agent that **recalls by meaning** — and survives restarts — with zero extra infrastructure and
+**no embedding API**.
+
+This is **Rung 2** of the [tool-layer example curriculum](https://github.com/language-operator/language-operator/issues/890).
+It registers the official [Qdrant MCP server](https://github.com/qdrant/mcp-server-qdrant)
+(`mcp-server-qdrant`, pinned to `v0.8.1`) as a `LanguageTool` and attaches it to a demo agent. It
+exposes two tools: `qdrant-store` (save a note) and `qdrant-find` (retrieve by semantic similarity).
+
+## The concept
+
+Rung 1 ([tools/memory](../memory/)) gave the agent an **exact-match** knowledge graph. This rung
+gives it **semantic recall**: store *"the launch retro is on Friday"*, then ask *"when's the
+postmortem?"* and `qdrant-find` returns the note — different words, same meaning. R1's graph
+**cannot** do that; matching meaning instead of strings is the whole point of R2.
+
+Three things make this work, all with **zero external backend**:
+
+- **`uvx` over stdio.** `mcp-server-qdrant` is a Python package, so the operator runs it under its
+  pinned stdio→Streamable-HTTP bridge using `uvx` — you don't wire up a bridge yourself. (R1 proved
+  the `npx` half of the bridge toolchain; this proves the `uvx` half.)
+- **Embedded Qdrant on the PVC.** `QDRANT_LOCAL_PATH=/workspace/.qdrant` runs Qdrant **embedded**
+  (in-process, no separate server) and writes the store to the agent's `/workspace` PVC. Combined
+  with `spec.deploymentMode: sidecar` — which injects the tool container **into the agent's own
+  pod** so it can see that PVC — the vectors outlive any single pod.
+- **Local FastEmbed embeddings.** `EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2` computes
+  embeddings **in-process** with [FastEmbed](https://github.com/qdrant/fastembed) — no API key, no
+  model gateway, no per-token cost. The model is downloaded once at boot and cached on the PVC.
+
+### Embedded vs server mode
+
+This example uses **embedded** mode: Qdrant is a library inside the sidecar, the store is a local
+file on the PVC, and there is exactly **one writer**. That is perfect for a single agent's private
+memory and needs no infrastructure — but it is **not shareable** across agents. The
+**server** mode (a standalone Qdrant reachable over the network, shared by many agents) is the
+subject of a later rung — see **R3** in the [curriculum](https://github.com/language-operator/language-operator/issues/890).
+
+> **Gotcha — sidecars need a workspace.** A sidecar tool can only persist if the agent has a
+> `/workspace` PVC. The demo agent enables one (`spec.workspace`, default-enabled). If you strip the
+> workspace, `QDRANT_LOCAL_PATH` lands on ephemeral storage and the demo no longer survives restarts.
+
+> **Gotcha — slow first start.** The first boot downloads both the `mcp-server-qdrant` package
+> (via `uvx`) and the FastEmbed model over HTTPS, so the tool can take a minute or two to reach
+> `Ready`. No custom probe is needed: the operator's bridge readiness probe already allows ~120s of
+> cold-start grace. Subsequent starts reuse the model cached on the PVC.
+
+## Prerequisites
+
+- Language Operator [installed](https://langop.io/docs/getting-started/installation/)
+- `kubectl` configured for your cluster
+- `envsubst` (`brew install gettext` on macOS, pre-installed on most Linux distros)
+- A `LanguageCluster` already applied in the target namespace (see [clusters/basic](../../clusters/basic/))
+- A `LanguageModel` in that cluster for the agent to use (see [models/anthropic](../../models/anthropic/))
+- Credentials for the `claude-code` runtime — an `anthropic-credentials` secret (`api-key`) **or**
+  a `claude-code-oauth` secret (`token`) in the cluster namespace
+
+## Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `CLUSTER_NAME` | yes | — | Namespace of the target LanguageCluster |
+| `MODEL_NAME` | yes | — | Name of a LanguageModel the demo agent should use |
+| `TOOL_NAME` | no | `qdrant` | Name of the LanguageTool CR (the name the agent references) |
+| `AGENT_NAME` | no | `qdrant-demo` | Name of the demo LanguageAgent CR |
+| `WORKSPACE_SIZE` | no | `10Gi` | Size of the agent's `/workspace` PVC |
+
+> **Egress:** the tool manifest grants outbound HTTPS (`0.0.0.0/0:443`) because the server fetches
+> two things at boot: its own package (via `uvx`) and the FastEmbed embedding model. There is no
+> runtime egress — once booted, store and search are fully local. The operator's default tool policy
+> denies external egress, so this boot-time rule is required.
+
+## Install
+
+```bash
+CLUSTER_NAME=my-cluster MODEL_NAME=my-model bash examples/tools/qdrant/install.sh
+```
+
+Dry-run (prints rendered YAML, applies nothing):
+```bash
+CLUSTER_NAME=my-cluster MODEL_NAME=my-model bash examples/tools/qdrant/install.sh --dry-run
+```
+
+## What's created
+
+- `LanguageTool/qdrant` — the MCP tool CR (`transport: stdio`, `deploymentMode: sidecar`)
+- `LanguageAgent/qdrant-demo` — a `claude-code` agent that references the tool and a model, with a
+  `/workspace` PVC for the sidecar to write to
+
+No secret and no backend are created — embedded Qdrant has no credentials and FastEmbed embeds locally.
+
+Once the tool reaches `Ready`, the operator's MCP handshake populates `status.toolSchemas`, which
+proves the server speaks MCP through the bridge — you should see `qdrant-store` and `qdrant-find`:
+
+```bash
+kubectl get languagetool qdrant -n my-cluster -o jsonpath='{.status.toolSchemas}' ; echo
+```
+
+The qdrant container runs **inside the agent pod** (sidecar). Confirm it and its `/workspace` mount:
+
+```bash
+kubectl get pod -n my-cluster -l app.kubernetes.io/name=qdrant-demo,langop.io/component=agent \
+  -o jsonpath='{.items[0].spec.containers[*].name}' ; echo
+```
+
+## The demo: recall by meaning, not by words
+
+1. **Tell the agent a note.** Talk to the `qdrant-demo` agent however your cluster exposes it and
+   give it something to remember in specific words, e.g. *"The launch retro is on Friday at 3pm."*
+   The agent stores it via `qdrant-store`.
+
+2. **Ask with different words.** *"When's the postmortem?"* — note that you never said "retro" or
+   "Friday". The agent calls `qdrant-find`, the vector search matches on *meaning*, and it answers
+   from the stored note. This is the headline contrast with R1: an exact-match store would find
+   nothing here.
+
+3. **(Bonus) Survive a pod delete.** The embedded store lives on the PVC, so it outlives the pod:
+   ```bash
+   kubectl delete pod -n my-cluster -l app.kubernetes.io/name=qdrant-demo,langop.io/component=agent
+   ```
+   After the Deployment reschedules a fresh pod (which re-attaches the same `/workspace` PVC and
+   reuses the cached embedding model), ask again — the note is still there.
+
+## Teardown
+
+```bash
+kubectl delete languageagent qdrant-demo -n my-cluster
+kubectl delete languagetool qdrant -n my-cluster
+```
+
+Deleting the agent also removes its `/workspace` PVC (and the stored vectors) per the cluster's
+reclaim policy.
+
+---
+
+Part of the [tool-layer example curriculum (R1–R7)](https://github.com/language-operator/language-operator/issues/890).

--- a/examples/tools/qdrant/install.sh
+++ b/examples/tools/qdrant/install.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Registers the official Qdrant MCP server in *embedded* mode as a sidecar LanguageTool and deploys
+# a demo claude-code agent that uses it for semantic memory. The sidecar persists its vector store
+# on the agent's /workspace PVC, so memory survives pod restarts with no external store and no
+# embedding API — FastEmbed computes embeddings locally.
+#
+# Usage: CLUSTER_NAME=my-cluster MODEL_NAME=my-model bash install.sh [--dry-run]
+set -euo pipefail
+
+: "${CLUSTER_NAME:?CLUSTER_NAME is required — set it to the name of your LanguageCluster}"
+: "${MODEL_NAME:?MODEL_NAME is required — set it to the name of a LanguageModel in that cluster}"
+export CLUSTER_NAME
+export MODEL_NAME
+export TOOL_NAME="${TOOL_NAME:-qdrant}"
+export AGENT_NAME="${AGENT_NAME:-qdrant-demo}"
+export WORKSPACE_SIZE="${WORKSPACE_SIZE:-10Gi}"
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Restrict substitution to our placeholders so any literal $VARs in the manifests survive to be
+# expanded inside the container at runtime.
+for f in "$DIR"/*.yaml; do
+    envsubst '$CLUSTER_NAME $MODEL_NAME $TOOL_NAME $AGENT_NAME $WORKSPACE_SIZE' < "$f" > "$TMPDIR/$(basename "$f")"
+done
+
+if $DRY_RUN; then
+    kubectl kustomize "$TMPDIR"
+    exit 0
+fi
+
+# No secret, no backend — embedded Qdrant has no credentials and writes only to /workspace, and
+# FastEmbed embeds locally with no API key.
+kubectl kustomize "$TMPDIR" | kubectl apply -f -

--- a/examples/tools/qdrant/kustomization.yaml
+++ b/examples/tools/qdrant/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - languagetool.qdrant.yaml
+  - languageagent.qdrant-demo.yaml

--- a/examples/tools/qdrant/languageagent.qdrant-demo.yaml
+++ b/examples/tools/qdrant/languageagent.qdrant-demo.yaml
@@ -1,0 +1,52 @@
+apiVersion: langop.io/v1alpha1
+kind: LanguageAgent
+metadata:
+  name: ${AGENT_NAME}
+  namespace: ${CLUSTER_NAME}
+spec:
+  runtime: claude-code
+  # Referencing the tool injects its sidecar into this pod and wires the MCP endpoint into the
+  # agent via MCP_SERVERS and /etc/agent/config.yaml.
+  tools:
+    - name: ${TOOL_NAME}
+  models:
+    - name: ${MODEL_NAME}
+  instructions: |
+    You have a persistent semantic memory backed by the "qdrant" MCP tool — a vector store
+    that retrieves notes by *meaning*, not exact words, and survives restarts.
+
+    - When the user tells you something worth remembering (a fact, a date, a preference),
+      store it with the qdrant-store tool as a short, self-contained note.
+    - When the user asks a question, search with the qdrant-find tool and answer from what
+      it returns — even if the user phrased the question with completely different words than
+      the note you stored. That semantic match is the whole point; do not guess.
+    - Treat the vector store as the source of truth across conversations and restarts.
+  # Sidecar tools require the agent to have a workspace: the embedded Qdrant store writes to
+  # /workspace (default-enabled). This PVC is what makes the vectors survive a pod restart.
+  workspace:
+    size: ${WORKSPACE_SIZE}
+  networkPolicies:
+    egress:
+      - to:
+          - cidr: "0.0.0.0/0"
+        ports:
+          - port: 443
+            protocol: TCP
+          - port: 80
+            protocol: TCP
+  deployment:
+    env:
+      # The claude-code runtime authenticates with either an Anthropic API key or an OAuth token.
+      # Both are optional here so the manifest applies cleanly; supply whichever your cluster uses.
+      - name: ANTHROPIC_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: anthropic-credentials
+            key: api-key
+            optional: true
+      - name: CLAUDE_CODE_OAUTH_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: claude-code-oauth
+            key: token
+            optional: true

--- a/examples/tools/qdrant/languagetool.qdrant.yaml
+++ b/examples/tools/qdrant/languagetool.qdrant.yaml
@@ -1,0 +1,51 @@
+apiVersion: langop.io/v1alpha1
+kind: LanguageTool
+metadata:
+  name: ${TOOL_NAME}
+  namespace: ${CLUSTER_NAME}
+spec:
+  # mcp-server-qdrant ships as a uvx (Python) stdio MCP server. transport=stdio tells the operator
+  # to run it under a pinned, persistent stdio→Streamable-HTTP bridge (one long-lived child) and
+  # serve /mcp on spec.port. The bridge image bundles Python+uv, so uvx works with no custom image;
+  # the operator injects the bridge, a writable cache + /tmp, and the readiness probe. (R1 proved
+  # the npx half of this toolchain; this is the uvx half.)
+  transport: stdio
+  port: 8080
+  # Sidecar mode injects the tool container into the agent's pod, where it can see the agent's
+  # /workspace PVC. That is what lets the embedded vector store survive a pod restart with zero
+  # extra infrastructure — no Qdrant server, no StatefulSet, no external store.
+  deploymentMode: sidecar
+  stdio:
+    command:
+      - uvx
+      # Pinned: env var names and embedded-mode behavior can drift between versions.
+      - "mcp-server-qdrant==0.8.1"
+  deployment:
+    # uvx resolves the package and downloads the FastEmbed embedding model on first boot, which
+    # pushes past the operator's 512Mi default and would get OOMKilled; give it 1Gi of headroom.
+    resources:
+      limits:
+        memory: 1Gi
+    env:
+      # Embedded mode: Qdrant runs in-process and writes to a local path — no separate server.
+      # Point it at the agent's /workspace PVC so the vectors survive a pod restart. Anywhere
+      # outside /workspace is ephemeral. The sidecar creates the .qdrant directory on first write.
+      - name: QDRANT_LOCAL_PATH
+        value: /workspace/.qdrant
+      - name: COLLECTION_NAME
+        value: memory
+      # Local FastEmbed embedding model — embeddings are computed in-process with no API key and no
+      # gateway. Downloaded once at boot (see the egress rule below), then cached on the PVC.
+      - name: EMBEDDING_MODEL
+        value: sentence-transformers/all-MiniLM-L6-v2
+  # The operator's default tool policy denies external egress. This server needs outbound HTTPS
+  # twice at boot: uvx fetches the package from PyPI, and FastEmbed downloads the embedding model.
+  # There is no runtime egress — once booted, store and search are fully local. No secret, no
+  # backend: this server has no credentials.
+  networkPolicies:
+    egress:
+      - to:
+          - cidr: "0.0.0.0/0"
+        ports:
+          - port: 443
+            protocol: TCP


### PR DESCRIPTION
Closes #892

Adds **Rung 2** of the tool-layer example curriculum (#890): `examples/tools/qdrant/` — semantic memory with local FastEmbed embeddings, embedded Qdrant on the agent's `/workspace` PVC, zero external backend.

Structurally mirrors R1 (`examples/tools/memory/`, #899). Validates the **uvx** half of the stdio bridge toolchain (R1 proved npx). No operator code changes — the bridge image already bundles Python+uv.

## Files
- `languagetool.qdrant.yaml` — `transport: stdio`, `deploymentMode: sidecar`, `uvx mcp-server-qdrant==0.8.1`, embedded mode env (`QDRANT_LOCAL_PATH`, `COLLECTION_NAME`, `EMBEDDING_MODEL`), 1Gi limit, `0.0.0.0/0:443` egress
- `languageagent.qdrant-demo.yaml` — `claude-code` demo agent with workspace, instructions to store/recall by meaning
- `kustomization.yaml`, `install.sh`, `README.md`

## Verification
- `CLUSTER_NAME=test MODEL_NAME=m bash examples/tools/qdrant/install.sh --dry-run` renders clean YAML
- Upstream env vars + default embedding model verified against `qdrant/mcp-server-qdrant` README (v0.8.1)
- All LanguageTool fields validated against the CRD schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)