### PR TITLE
feat(examples): R3 — RAG over a seeded corpus (bundled Qdrant StatefulSet + ingestion Job)

### DIFF
--- a/examples/knowledge/rag/README.md
+++ b/examples/knowledge/rag/README.md
@@ -1,0 +1,166 @@
+# knowledge/rag
+
+An agent that **answers from a private knowledge base and cites its source** — RAG over a
+**seeded corpus**, with the vector store living in a real, bundled Qdrant server. Zero external
+infrastructure and **no embedding API**.
+
+This is **Rung 3** of the [tool-layer example curriculum](https://github.com/language-operator/language-operator/issues/890),
+and the first entry in the `examples/knowledge/` family. It deploys a self-contained
+[Qdrant](https://github.com/qdrant/qdrant) `StatefulSet`, loads a demo corpus into it with a
+one-shot ingestion `Job`, and registers the official
+[Qdrant MCP server](https://github.com/qdrant/mcp-server-qdrant) (`mcp-server-qdrant`, pinned to
+`v0.8.1`) as a **read-only** `LanguageTool` the agent uses to retrieve.
+
+## The concept
+
+R1 ([tools/memory](../../tools/memory/)) and R2 ([tools/qdrant](../../tools/qdrant/)) gave an agent
+a memory it **writes to itself**, persisted on its own `/workspace` PVC via a **sidecar** tool. RAG
+is the opposite shape: a **curated corpus the agent only reads**. Two things change because of that:
+
+- **sidecar → service.** A service-mode stdio bridge has only ephemeral scratch, so the corpus
+  can't live "inside" the tool — it must sit in a real backend. This rung stands up a Qdrant
+  `StatefulSet` with its own PVC, exactly as [tools/postgres](../../tools/postgres/) does for SQL.
+  One standalone tool (`deploymentMode: service`) can then be shared by many agents.
+- **read-only → retrieval, not memory.** `QDRANT_READ_ONLY=true` makes `mcp-server-qdrant` expose
+  only `qdrant-find` (no `qdrant-store`). That is the headline contrast with R2: agents *retrieve*
+  from the corpus, they can't mutate it. The corpus is seeded once, out of band, by the Job.
+
+Everything still runs with **no embedding API**: [FastEmbed](https://github.com/qdrant/fastembed)
+computes embeddings locally, both when the Job ingests and when the tool answers a query.
+
+### How the corpus is seeded
+
+```
+configmap.corpus.yaml ──▶ Job (uv + qdrant-client[fastembed]) ──embeds & upserts──▶ Qdrant "kb"
+                                                                                         ▲
+                          LanguageTool (mcp-server-qdrant, read-only) ──qdrant-find──────┘
+                                                                                         │
+                                                          LanguageAgent (claude-code) ───┘
+```
+
+The `Job` embeds each doc with FastEmbed and writes points into collection `kb` in the **exact wire
+format** `mcp-server-qdrant` reads back — named vector `fast-<model>`, payload
+`{"document", "metadata"}`, cosine distance. It is **idempotent**: each point's ID is derived
+deterministically from the doc's `id` (`uuid5`), so re-running upserts in place and never
+duplicates. `install.sh` deletes any prior `kb-ingest` Job before re-applying (a Job's pod template
+is immutable), so a second `install.sh` genuinely re-ingests — and still ends with one point per doc.
+
+### ⚠️ The embedding model must match
+
+The ingestion Job and the tool **must** use the same `EMBEDDING_MODEL`. Different models produce
+different vectors *and* a different vector name (`fast-<model>`), so a mismatch makes `qdrant-find`
+query an empty vector and **silently return nothing** — no error, just bad answers. This example
+feeds **one** `${EMBEDDING_MODEL}` variable into both manifests so they can't drift; keep it that
+way if you swap the model.
+
+## Single-secret wiring
+
+One secret, `qdrant-credentials` (key `api-key`), is the single source of truth. `install.sh`
+generates it once (and reuses it on re-runs, so it never drifts from the key baked into the
+persisted PVC) and wires it into all three consumers:
+
+| Consumer | Reads the key as |
+|----------|------------------|
+| Qdrant `StatefulSet` | `QDRANT__SERVICE__API_KEY` (turns on auth) |
+| `LanguageTool` (mcp-server-qdrant) | `QDRANT_API_KEY` |
+| Ingestion `Job` | `QDRANT_API_KEY` |
+
+## Prerequisites
+
+- Language Operator [installed](https://langop.io/docs/getting-started/installation/)
+- `kubectl` configured for your cluster
+- `envsubst` (`brew install gettext` on macOS, pre-installed on most Linux distros)
+- `openssl` (for API-key generation — pre-installed on macOS and most Linux distros)
+- A `LanguageCluster` already applied in the target namespace (see [clusters/basic](../../clusters/basic/))
+- A `LanguageModel` in that cluster for the demo agent (see [models/anthropic](../../models/anthropic/))
+- A default StorageClass (the Qdrant StatefulSet requests a 1Gi PVC)
+- Credentials for the `claude-code` runtime — an `anthropic-credentials` secret (`api-key`) **or**
+  a `claude-code-oauth` secret (`token`) in the cluster namespace
+
+## Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `CLUSTER_NAME` | yes | — | Namespace of the target LanguageCluster |
+| `MODEL_NAME` | yes | — | Name of a LanguageModel the demo agent should use |
+| `TOOL_NAME` | no | `kb` | Name of the LanguageTool CR (the name the agent references); also prefixes the bundled `${TOOL_NAME}-db` Qdrant resources |
+| `AGENT_NAME` | no | `rag-demo` | Name of the demo LanguageAgent CR |
+| `EMBEDDING_MODEL` | no | `sentence-transformers/all-MiniLM-L6-v2` | FastEmbed model — fed to **both** the Job and the tool |
+
+> **Egress:** the tool manifest grants outbound HTTPS (`0.0.0.0/0:443`) for the boot-time `uvx`
+> package fetch and FastEmbed model download. Qdrant is in the same namespace, which the operator's
+> default tool policy already allows, so no backend egress rule is needed.
+
+## Install
+
+```bash
+CLUSTER_NAME=my-cluster MODEL_NAME=my-model bash examples/knowledge/rag/install.sh
+```
+
+Dry-run (prints rendered YAML, applies nothing):
+```bash
+CLUSTER_NAME=my-cluster MODEL_NAME=my-model bash examples/knowledge/rag/install.sh --dry-run
+```
+
+## What's created
+
+- `Secret/qdrant-credentials` — auto-generated `api-key`, the single source of truth
+- `StatefulSet/kb-db` + its 1Gi `PersistentVolumeClaim` — the bundled Qdrant server
+- `Service/kb-db` — headless service giving Qdrant stable in-cluster DNS (REST 6333, gRPC 6334)
+- `ConfigMap/kb-corpus` — the demo corpus (`corpus.json`)
+- `ConfigMap/kb-ingest-script` + `Job/kb-ingest` — the one-shot, idempotent ingestion
+- `LanguageTool/kb` — the read-only MCP tool CR (`transport: stdio`, `deploymentMode: service`)
+- `Deployment/kb` + `Service/kb` — the operator-injected bridge running `mcp-server-qdrant`, exposing
+  `/mcp` in-cluster on port 8080
+- `LanguageAgent/rag-demo` — a `claude-code` agent that retrieves from `kb` and cites sources
+
+Watch the ingestion finish, then confirm the tool exposes **only** `qdrant-find` (read-only → no
+`qdrant-store`):
+
+```bash
+kubectl wait --for=condition=complete job/kb-ingest -n my-cluster --timeout=300s
+kubectl get languagetool kb -n my-cluster -o jsonpath='{.status.toolSchemas}' ; echo
+```
+
+> **Gotcha — slow first start.** The Job and the tool each download the FastEmbed model and their
+> packages over HTTPS on first boot, so both can take a minute or two. The operator's bridge
+> readiness probe already allows ~120s of cold-start grace; no custom probe is needed.
+
+## The demo: grounded answers with citations
+
+Talk to the `rag-demo` agent however your cluster exposes it.
+
+1. **Ask something in the corpus.** *"How many PTO days do engineers get, and what happens to unused
+   days?"* The agent calls `qdrant-find`, retrieves the **Time Off Policy** doc, and answers from it
+   — *"26 days, accrued monthly; up to 10 roll over, the rest is paid out in January (source: Time
+   Off Policy)."* The facts are fictional (about "Meridian Robotics"), so a correct, specific answer
+   can only have come from retrieval.
+
+2. **Ask something outside the corpus.** *"What's Meridian Robotics' stock price?"* Nothing in the
+   knowledge base grounds it, so the agent declines — *"That isn't in the knowledge base."* — rather
+   than guessing from world knowledge. That refusal is the point of a RAG agent.
+
+## Swap in your own corpus
+
+Replace `corpus.json` in [configmap.corpus.yaml](configmap.corpus.yaml) with your own docs (keep the
+`{"id", "title", "text"}` shape — `id` drives the deterministic point ID, `title` is the citation
+label), then re-run `install.sh`. Keep `EMBEDDING_MODEL` identical between runs, or re-ingest into a
+fresh collection.
+
+## Teardown
+
+```bash
+kubectl delete languageagent rag-demo -n my-cluster
+kubectl delete languagetool kb -n my-cluster
+kubectl delete job kb-ingest -n my-cluster
+kubectl delete statefulset kb-db -n my-cluster
+kubectl delete service kb-db -n my-cluster
+kubectl delete configmap kb-corpus kb-ingest-script -n my-cluster
+kubectl delete secret qdrant-credentials -n my-cluster
+# The PVC is retained by default — delete it to wipe the corpus (and allow a fresh API key):
+kubectl delete pvc storage-kb-db-0 -n my-cluster
+```
+
+---
+
+Part of the [tool-layer example curriculum (R1–R7)](https://github.com/language-operator/language-operator/issues/890).

--- a/examples/knowledge/rag/configmap.corpus.yaml
+++ b/examples/knowledge/rag/configmap.corpus.yaml
@@ -1,0 +1,45 @@
+# The demo corpus the agent grounds its answers in. These are facts about a *fictional* company
+# (Meridian Robotics) that no base model could know, which makes the end-to-end test unambiguous:
+# in-corpus questions get a grounded, cited answer; anything else must be declined. Swap this file
+# for your own docs (keep the {id, title, text} shape) and re-run install.sh to re-ingest.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${TOOL_NAME}-corpus
+  namespace: ${CLUSTER_NAME}
+  labels:
+    app: ${TOOL_NAME}-ingest
+data:
+  corpus.json: |
+    [
+      {
+        "id": "onboarding-laptop",
+        "title": "Onboarding: Laptop Setup",
+        "text": "New engineers at Meridian Robotics receive a standard-issue laptop preloaded with the Meridian Toolbelt. Run `mrb doctor` on your first day to verify the setup; it checks your VPN profile, signs you into the internal package registry at registry.meridian.internal, and provisions a short-lived SSH certificate that must be renewed every 18 hours with `mrb auth renew`."
+      },
+      {
+        "id": "pto-policy",
+        "title": "Time Off Policy",
+        "text": "Meridian Robotics grants 26 days of paid time off per year, accrued monthly. Unused days roll over up to a cap of 10 days into the next calendar year; anything above the cap is paid out at the end of January. PTO requests are filed in the Atlas portal and auto-approve after 3 business days unless your manager intervenes."
+      },
+      {
+        "id": "deploy-process",
+        "title": "Production Deploy Process",
+        "text": "Production deploys at Meridian Robotics happen through the Conductor pipeline. A deploy requires two approvals: one from a service owner and one from the on-call SRE. Conductor freezes all deploys on Fridays after 2pm and for the full week around the company offsite. Emergency hotfixes bypass the freeze with the `--break-glass` flag, which pages the VP of Engineering automatically."
+      },
+      {
+        "id": "oncall-rotation",
+        "title": "On-Call Rotation",
+        "text": "The on-call rotation at Meridian Robotics is weekly, handed off every Monday at 10am Pacific. The primary on-call carries the pager; the secondary is the escalation point after 15 minutes of no acknowledgement. On-call engineers earn a stipend of 400 credits per week and one comp day per shift, redeemable through the Atlas portal."
+      },
+      {
+        "id": "robot-naming",
+        "title": "Robot Fleet Naming Convention",
+        "text": "Every robot in the Meridian fleet is named after a constellation followed by a three-digit hull number, for example 'Lyra-204'. Hull numbers below 100 are reserved for prototypes that never left the Halibut Lab. The flagship warehouse model is the Orion class; the newer cold-storage variant is the Orion-Frost, rated to operate down to minus 30 Celsius."
+      },
+      {
+        "id": "incident-severity",
+        "title": "Incident Severity Levels",
+        "text": "Meridian Robotics classifies incidents from SEV-1 (a robot has stopped a production line, customer-visible) down to SEV-4 (cosmetic or internal-only). A SEV-1 requires an incident commander to be paged within 5 minutes and a written postmortem within 48 hours. Postmortems are blameless and stored in the Beacon knowledge base."
+      }
+    ]

--- a/examples/knowledge/rag/install.sh
+++ b/examples/knowledge/rag/install.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Deploys a self-contained Qdrant vector DB (StatefulSet), seeds it from a demo corpus via a
+# one-shot ingestion Job, and registers a read-only mcp-server-qdrant LanguageTool plus a demo
+# claude-code agent that answers questions grounded in that corpus. No external vector DB required.
+#
+# Usage: CLUSTER_NAME=my-cluster MODEL_NAME=my-model bash install.sh [--dry-run]
+set -euo pipefail
+
+: "${CLUSTER_NAME:?CLUSTER_NAME is required — set it to the name of your LanguageCluster}"
+: "${MODEL_NAME:?MODEL_NAME is required — set it to the name of a LanguageModel in that cluster}"
+export CLUSTER_NAME
+export MODEL_NAME
+export TOOL_NAME="${TOOL_NAME:-kb}"
+export AGENT_NAME="${AGENT_NAME:-rag-demo}"
+# One model drives both the ingestion Job and the tool's query embedding — they MUST match, so a
+# single variable feeds both manifests.
+export EMBEDDING_MODEL="${EMBEDDING_MODEL:-sentence-transformers/all-MiniLM-L6-v2}"
+
+SECRET_NAME="qdrant-credentials"
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Restrict substitution to our placeholders so any literal $VARs in the manifests survive to be
+# expanded inside the container at runtime.
+for f in "$DIR"/*.yaml; do
+    envsubst '$CLUSTER_NAME $MODEL_NAME $TOOL_NAME $AGENT_NAME $EMBEDDING_MODEL' \
+        < "$f" > "$TMPDIR/$(basename "$f")"
+done
+
+if $DRY_RUN; then
+    kubectl kustomize "$TMPDIR"
+    exit 0
+fi
+
+# Generate the API key once and reuse it on re-runs, so it never drifts from the key baked into the
+# persisted Qdrant PVC on first boot. This single secret is the source of truth: the StatefulSet
+# reads it as QDRANT__SERVICE__API_KEY; the tool and ingestion Job read it as QDRANT_API_KEY.
+API_KEY="$(kubectl get secret "$SECRET_NAME" -n "$CLUSTER_NAME" \
+    -o jsonpath='{.data.api-key}' 2>/dev/null | base64 -d || true)"
+if [[ -z "$API_KEY" ]]; then
+    API_KEY="$(openssl rand -hex 32)"
+fi
+
+kubectl create secret generic "$SECRET_NAME" \
+    --from-literal=api-key="$API_KEY" \
+    --namespace "$CLUSTER_NAME" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+# A Job's pod template is immutable, so a re-run of install.sh can't update an existing kb-ingest
+# Job in place. Delete it first so it actually re-runs — deterministic point IDs make that safe
+# (the second ingest upserts the same points, never duplicating them).
+kubectl delete job kb-ingest -n "$CLUSTER_NAME" --ignore-not-found
+
+kubectl kustomize "$TMPDIR" | kubectl apply -f -

--- a/examples/knowledge/rag/job.kb-ingest.yaml
+++ b/examples/knowledge/rag/job.kb-ingest.yaml
@@ -1,0 +1,145 @@
+# One-shot job that embeds the demo corpus and loads it into the bundled Qdrant. It writes points
+# in the EXACT format mcp-server-qdrant reads back (named vector `fast-<model>`, payload
+# {"document", "metadata"}, cosine distance) so the tool's qdrant-find retrieves them. The job is
+# idempotent: point IDs are derived deterministically from each doc's id (uuid5), so re-running
+# upserts in place and never duplicates. install.sh deletes any prior Job before re-applying, so a
+# second `install.sh` actually re-ingests — and still ends with exactly one point per doc.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${TOOL_NAME}-ingest-script
+  namespace: ${CLUSTER_NAME}
+  labels:
+    app: ${TOOL_NAME}-ingest
+data:
+  ingest.py: |
+    """Embed the corpus and upsert it into Qdrant in mcp-server-qdrant's wire format."""
+    import json
+    import os
+    import sys
+    import time
+    import uuid
+
+    from fastembed import TextEmbedding
+    from qdrant_client import QdrantClient, models
+
+    QDRANT_URL = os.environ["QDRANT_URL"]
+    API_KEY = os.environ.get("QDRANT_API_KEY") or None
+    COLLECTION = os.environ.get("COLLECTION_NAME", "kb")
+    MODEL = os.environ.get("EMBEDDING_MODEL", "sentence-transformers/all-MiniLM-L6-v2")
+    CORPUS_PATH = os.environ.get("CORPUS_PATH", "/corpus/corpus.json")
+
+    # mcp-server-qdrant names its vector `fast-<last path segment, lowercased>`. We MUST match this
+    # exactly or qdrant-find queries a vector name that holds no points and silently returns nothing.
+    VECTOR_NAME = "fast-" + MODEL.split("/")[-1].lower()
+
+    with open(CORPUS_PATH) as f:
+        docs = json.load(f)
+    if not docs:
+        print("corpus is empty, nothing to ingest")
+        sys.exit(0)
+
+    print(f"embedding {len(docs)} docs with {MODEL} (vector '{VECTOR_NAME}')", flush=True)
+    embedder = TextEmbedding(model_name=MODEL)
+    # passage_embed is what mcp-server-qdrant uses for stored documents; for MiniLM it is identical
+    # to query_embed, so retrieval matches regardless.
+    vectors = [v.tolist() for v in embedder.passage_embed([d["text"] for d in docs])]
+    dim = len(vectors[0])
+
+    client = QdrantClient(url=QDRANT_URL, api_key=API_KEY)
+
+    # Wait for Qdrant to accept connections before touching collections — the StatefulSet may still
+    # be coming up when this Job starts.
+    for attempt in range(60):
+        try:
+            client.get_collections()
+            break
+        except Exception as exc:  # noqa: BLE001 — any transport/auth error is worth retrying briefly
+            print(f"waiting for qdrant ({attempt + 1}/60): {exc}", flush=True)
+            time.sleep(5)
+    else:
+        sys.exit("qdrant did not become reachable in time")
+
+    if not client.collection_exists(COLLECTION):
+        client.create_collection(
+            collection_name=COLLECTION,
+            vectors_config={VECTOR_NAME: models.VectorParams(size=dim, distance=models.Distance.COSINE)},
+        )
+        print(f"created collection '{COLLECTION}'", flush=True)
+
+    points = [
+        models.PointStruct(
+            # Deterministic id keyed on the doc's stable id → re-runs upsert in place (idempotent).
+            id=str(uuid.uuid5(uuid.NAMESPACE_URL, doc["id"])),
+            vector={VECTOR_NAME: vec},
+            # Payload shape mcp-server-qdrant expects: the text under "document", everything else
+            # under "metadata" (qdrant-find surfaces both, so the agent can cite the title).
+            payload={"document": doc["text"], "metadata": {"title": doc["title"], "source": doc["id"]}},
+        )
+        for doc, vec in zip(docs, vectors)
+    ]
+    client.upsert(collection_name=COLLECTION, points=points, wait=True)
+
+    count = client.count(COLLECTION).count
+    print(f"upserted {len(points)} points; collection '{COLLECTION}' now holds {count}", flush=True)
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kb-ingest
+  namespace: ${CLUSTER_NAME}
+  labels:
+    app: ${TOOL_NAME}-ingest
+spec:
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        app: ${TOOL_NAME}-ingest
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: ingest
+          image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+          # uv resolves qdrant-client[fastembed] on the fly (no custom image) and runs the script.
+          command: ["uv", "run", "--no-project", "--with", "qdrant-client[fastembed]", "python", "/scripts/ingest.py"]
+          env:
+            - name: QDRANT_URL
+              value: http://${TOOL_NAME}-db.${CLUSTER_NAME}.svc.cluster.local:6333
+            - name: QDRANT_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: qdrant-credentials
+                  key: api-key
+            - name: COLLECTION_NAME
+              value: kb
+            # MUST match the LanguageTool's EMBEDDING_MODEL — install.sh substitutes the same
+            # ${EMBEDDING_MODEL} into both from one variable, so they cannot drift. Different models
+            # produce different vectors (and vector names); retrieval silently returns garbage if
+            # they diverge.
+            - name: EMBEDDING_MODEL
+              value: ${EMBEDDING_MODEL}
+            # uv's cache, the FastEmbed model download, and $HOME all need a writable path; the
+            # image's root filesystem is fine but an emptyDir keeps the Job self-contained.
+            - name: HOME
+              value: /tmp
+            - name: UV_CACHE_DIR
+              value: /tmp/uv-cache
+          volumeMounts:
+            - name: corpus
+              mountPath: /corpus
+              readOnly: true
+            - name: script
+              mountPath: /scripts
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: corpus
+          configMap:
+            name: ${TOOL_NAME}-corpus
+        - name: script
+          configMap:
+            name: ${TOOL_NAME}-ingest-script
+        - name: tmp
+          emptyDir: {}

--- a/examples/knowledge/rag/kustomization.yaml
+++ b/examples/knowledge/rag/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.corpus.yaml
+  - statefulset.qdrant.yaml
+  - job.kb-ingest.yaml
+  - languagetool.kb.yaml
+  - languageagent.rag-demo.yaml

--- a/examples/knowledge/rag/languageagent.rag-demo.yaml
+++ b/examples/knowledge/rag/languageagent.rag-demo.yaml
@@ -1,0 +1,51 @@
+apiVersion: langop.io/v1alpha1
+kind: LanguageAgent
+metadata:
+  name: ${AGENT_NAME}
+  namespace: ${CLUSTER_NAME}
+spec:
+  runtime: claude-code
+  # Referencing the tool injects its MCP endpoint into this agent via MCP_SERVERS and
+  # /etc/agent/config.yaml. The tool runs as a shared standalone Service (deploymentMode: service),
+  # not a sidecar, so this agent needs no workspace of its own.
+  tools:
+    - name: ${TOOL_NAME}
+  models:
+    - name: ${MODEL_NAME}
+  instructions: |
+    You answer strictly from a private knowledge base exposed by the "${TOOL_NAME}" MCP tool, which
+    offers a single retrieval tool: qdrant-find. The knowledge base is read-only — there is no way
+    to store new facts, and you must not try.
+
+    For every question:
+    - Call qdrant-find first and read what it returns. Each result carries the source document's
+      text plus metadata including its title.
+    - If the results ground an answer, answer ONLY from them and cite the source title, e.g.
+      "(source: Time Off Policy)". Do not add facts the retrieval did not return.
+    - If qdrant-find returns nothing relevant, say the answer is not in the knowledge base. Do not
+      guess, and do not fall back on general world knowledge.
+  networkPolicies:
+    egress:
+      - to:
+          - cidr: "0.0.0.0/0"
+        ports:
+          - port: 443
+            protocol: TCP
+          - port: 80
+            protocol: TCP
+  deployment:
+    env:
+      # The claude-code runtime authenticates with either an Anthropic API key or an OAuth token.
+      # Both are optional here so the manifest applies cleanly; supply whichever your cluster uses.
+      - name: ANTHROPIC_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: anthropic-credentials
+            key: api-key
+            optional: true
+      - name: CLAUDE_CODE_OAUTH_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: claude-code-oauth
+            key: token
+            optional: true

--- a/examples/knowledge/rag/languagetool.kb.yaml
+++ b/examples/knowledge/rag/languagetool.kb.yaml
@@ -1,0 +1,57 @@
+apiVersion: langop.io/v1alpha1
+kind: LanguageTool
+metadata:
+  name: ${TOOL_NAME}
+  namespace: ${CLUSTER_NAME}
+spec:
+  # mcp-server-qdrant ships as a uvx (Python) stdio MCP server. transport=stdio tells the operator
+  # to run it under a pinned, persistent stdio->Streamable-HTTP bridge serving /mcp on spec.port.
+  transport: stdio
+  port: 8080
+  # service mode (the default) deploys the tool as a standalone Deployment+Service, shared across
+  # agents. R2 used sidecar mode so an embedded store could ride the agent's /workspace PVC. Here
+  # the data lives in the Qdrant StatefulSet instead, so the bridge needs no persistence of its own
+  # and one shared tool can serve many agents — the jump this rung is built to teach.
+  deploymentMode: service
+  stdio:
+    command:
+      - uvx
+      # Pinned: env var names and server behavior can drift between versions (matches R2).
+      - "mcp-server-qdrant==0.8.1"
+  deployment:
+    # uvx resolves the package and downloads the FastEmbed model on first boot, pushing past the
+    # operator's 512Mi default; give it 1Gi of headroom so it isn't OOMKilled.
+    resources:
+      limits:
+        memory: 1Gi
+    env:
+      # Point the server at the bundled Qdrant StatefulSet (same namespace). REST port 6333.
+      - name: QDRANT_URL
+        value: http://${TOOL_NAME}-db.${CLUSTER_NAME}.svc.cluster.local:6333
+      # Same secret the StatefulSet's QDRANT__SERVICE__API_KEY reads — single source of truth.
+      - name: QDRANT_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: qdrant-credentials
+            key: api-key
+      - name: COLLECTION_NAME
+        value: kb
+      # MUST match the ingestion Job's EMBEDDING_MODEL — install.sh substitutes the same
+      # ${EMBEDDING_MODEL} into both, so they cannot drift. If they did, qdrant-find would embed
+      # queries with a different model and retrieval would silently return garbage.
+      - name: EMBEDDING_MODEL
+        value: ${EMBEDDING_MODEL}
+      # Read-only is what makes this a *retrieval* tool, not a memory tool: the server exposes only
+      # qdrant-find (no qdrant-store), so agents query the curated corpus but can't mutate it.
+      - name: QDRANT_READ_ONLY
+        value: "true"
+  # The operator's default tool policy denies external egress but allows all same-namespace traffic,
+  # so reaching the bundled Qdrant (same namespace, 6333) needs no rule. The only external egress is
+  # HTTPS (443) at boot: uvx fetches the package from PyPI and FastEmbed downloads the query model.
+  networkPolicies:
+    egress:
+      - to:
+          - cidr: "0.0.0.0/0"
+        ports:
+          - port: 443
+            protocol: TCP

--- a/examples/knowledge/rag/statefulset.qdrant.yaml
+++ b/examples/knowledge/rag/statefulset.qdrant.yaml
@@ -1,0 +1,84 @@
+# Self-contained Qdrant vector database for the RAG knowledge base. This is a plain StatefulSet —
+# not a LanguageTool — so the operator applies no NetworkPolicy to it; in-cluster pods (the tool's
+# stdio bridge and the ingestion Job, both same-namespace) reach it on 6333/6334. Unlike R2's
+# embedded Qdrant (a library inside the sidecar, on the agent's PVC), this is a real server with its
+# own persistent volume — the corpus must outlive every agent and tool pod and be shared read-only.
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${TOOL_NAME}-db
+  namespace: ${CLUSTER_NAME}
+  labels:
+    app: ${TOOL_NAME}-db
+spec:
+  clusterIP: None  # headless — stable per-pod DNS for the StatefulSet
+  selector:
+    app: ${TOOL_NAME}-db
+  ports:
+    - name: rest
+      port: 6333
+      targetPort: 6333
+    - name: grpc
+      port: 6334
+      targetPort: 6334
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ${TOOL_NAME}-db
+  namespace: ${CLUSTER_NAME}
+  labels:
+    app: ${TOOL_NAME}-db
+spec:
+  serviceName: ${TOOL_NAME}-db
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${TOOL_NAME}-db
+  template:
+    metadata:
+      labels:
+        app: ${TOOL_NAME}-db
+    spec:
+      containers:
+        - name: qdrant
+          image: qdrant/qdrant:v1.18.2
+          ports:
+            - name: rest
+              containerPort: 6333
+            - name: grpc
+              containerPort: 6334
+          env:
+            # API key comes from the same secret the LanguageTool's QDRANT_API_KEY reads, so the
+            # server and the tool can never drift out of sync. Setting it turns on auth: every REST
+            # and gRPC request must present this key (the health endpoints below stay open).
+            - name: QDRANT__SERVICE__API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: qdrant-credentials
+                  key: api-key
+          volumeMounts:
+            - name: storage
+              mountPath: /qdrant/storage
+          readinessProbe:
+            # /readyz, /livez and /healthz are unauthenticated regardless of the API key, so no
+            # header wiring is needed in the probe.
+            httpGet:
+              path: /readyz
+              port: 6333
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 6333
+            initialDelaySeconds: 30
+            periodSeconds: 15
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi


### PR DESCRIPTION
Closes #893

**Rung 3** of the tool-layer example curriculum (#890) — the first entry in `examples/knowledge/`.

Teaches the jump from R2's **sidecar/embedded** memory to **service mode** with a **bundled backend**: the agent retrieves from a private, pre-seeded knowledge base it can't write to.

## What's here (`examples/knowledge/rag/`)
- `statefulset.qdrant.yaml` — self-contained `qdrant/qdrant:v1.18.2` server (REST 6333 / gRPC 6334, 1Gi PVC).
- `configmap.corpus.yaml` — a small demo corpus about a *fictional* company so the in-corpus vs out-of-corpus E2E is unambiguous.
- `job.kb-ingest.yaml` — one-shot, **idempotent** ingestion (uv + `qdrant-client[fastembed]`); deterministic `uuid5` point IDs.
- `languagetool.kb.yaml` — `mcp-server-qdrant` in **service mode**, **read-only** (`QDRANT_READ_ONLY=true` → only `qdrant-find`).
- `languageagent.rag-demo.yaml` — `claude-code` agent that answers from `kb` and cites sources, declines when not grounded.
- `kustomization.yaml`, `install.sh`, `README.md`.

## Key correctness detail
The ingestion Job writes points in the **exact** format `mcp-server-qdrant` reads back — named vector `fast-<model>`, payload `{"document","metadata"}`, cosine distance — verified against upstream. One `${EMBEDDING_MODEL}` variable feeds both the Job and the tool so they can't drift (a mismatch silently breaks retrieval). One `qdrant-credentials` secret is the single source of truth, generated once and reused on re-runs (postgres pattern).

## Verification
- `install.sh --dry-run` renders clean; all resources pass `kubectl apply --dry-run=client` against live CRDs.
- `ingest.py` compiles; `corpus.json` parses (6 docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)